### PR TITLE
Pyramid setup + cmdi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
       run: tox -e black,flake8
 
   test:
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -3,21 +3,23 @@
 A library of purposely-vulnerable Python functions. These serve as a foundation for creating
 insecure web applications, to be used for security testing and demonstration.
 
-Do not use this library in a production environment!
+**WARNING: Do not use this library in a production environment!**
 
 ## Installation
 
 VulnPy contains both standalone functions and plug-and-play API extensions to various popular
 Python web frameworks. To use vulnpy with your web framework, be sure to install this package with
-the appropriate extra dependencies specified.
+the appropriate extra dependencies specified - detailed below.
 
-For example, for Flask, use the following command:
+### Flask
+
+Install vulnpy with flask extensions:
 
 ```
 pip install 'git+git://github.com/Contrast-Security-OSS/vulnpy#egg=vulnpy[flask]'
 ```
 
-Then, when setting up your application, register the vulnerable blueprint to your `Flask`
+When setting up your application, register the vulnerable blueprint to your `Flask`
 application object:
 
 ```py
@@ -25,4 +27,19 @@ from vulnpy.flask import vulnerable_blueprint
 
 app = Flask(__name__)
 app.register_blueprint(vulnerable_blueprint)
+```
+
+### Pyramid
+
+Install vulnpy with pyramid extensions:
+
+```
+pip install 'git+git://github.com/Contrast-Security-OSS/vulnpy#egg=vulnpy[pyramid]'
+```
+
+During application configuration, include vulnpy's vulnerable routes:
+
+```py
+config = Configurator()
+config.include("vulnpy.pyramid.vulnerable_routes", route_prefix="/vulnpy")
 ```

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ django_extras = ["Django"]
 falcon_extras = ["falcon"]
 flask_extras = ["Flask"]
 pyramid_extras = ["pyramid"]
-all_extras = django_extras + falcon_extras + flask_extras + pyramid_extras
+testing_extras = ["WebTest"]
+all_extras = (
+    django_extras + falcon_extras + flask_extras + pyramid_extras + testing_extras
+)
 
 setup(
     name="vulnpy",

--- a/src/vulnpy/pyramid/vulnerable_routes.py
+++ b/src/vulnpy/pyramid/vulnerable_routes.py
@@ -1,0 +1,41 @@
+from pyramid.response import Response
+
+from vulnpy.trigger import cmdi
+
+
+def _home(request):
+    return Response("vulnpy root")
+
+
+def _cmdi_os_system(request):
+    user_input = _get_user_input(request)
+    status = cmdi.do_os_system(user_input)
+    return Response(str(status))
+
+
+def _cmdi_subprocess_popen(request):
+    user_input = _get_user_input(request)
+    split_user_input = user_input.split()
+    try:
+        output = cmdi.do_subprocess_popen(split_user_input)
+    except Exception as e:
+        return Response(str(e), 400)
+    return Response(output)
+
+
+def _get_user_input(request):
+    if request.method == "GET":
+        return request.GET.get("user_input", "")
+    return request.POST.get("user_input", "")
+
+
+def includeme(config):
+    """
+    config.include looks for a function with this name specifically
+    """
+    config.add_route("vulnpy-root", "")
+    config.add_view(_home, route_name="vulnpy-root")
+    config.add_route("cmdi-os-system", "/cmdi/os-system")
+    config.add_view(_cmdi_os_system, route_name="cmdi-os-system")
+    config.add_route("cmdi-subprocess-popen", "/cmdi/subprocess-popen")
+    config.add_view(_cmdi_subprocess_popen, route_name="cmdi-subprocess-popen")

--- a/tests/pyramid/test_vulnerable_routes.py
+++ b/tests/pyramid/test_vulnerable_routes.py
@@ -1,0 +1,51 @@
+import pytest
+from pyramid.config import Configurator
+from webtest import TestApp
+
+
+@pytest.fixture
+def client():
+    config = Configurator()
+    config.include("vulnpy.pyramid.vulnerable_routes", route_prefix="/vulnpy")
+    app = config.make_wsgi_app()
+    yield TestApp(app)
+
+
+def test_home(client):
+    response = client.get("/vulnpy/")
+    assert response.status_int == 200
+
+
+@pytest.mark.parametrize("method_name", ["get", "post"])
+def test_cmdi_os_system_normal(client, method_name):
+    get_or_post = getattr(client, method_name)
+    response = get_or_post("/vulnpy/cmdi/os-system", {"user_input": "echo attack"})
+    assert int(response.body) == 0
+
+
+def test_cmdi_os_system_bad_command(client):
+    response = client.get("/vulnpy/cmdi/os-system", {"user_input": "foo"})
+    assert int(response.body) != 0
+
+
+def test_cmdi_os_system_invalid_input(client):
+    response = client.get("/vulnpy/cmdi/os-system", {"ignored_param": "bad"})
+    assert int(response.body) == 0
+    assert response.status_int == 200
+
+
+@pytest.mark.parametrize("method_name", ["get", "post"])
+def test_cmdi_subprocess_popen_normal(client, method_name):
+    get_or_post = getattr(client, method_name)
+    response = get_or_post(
+        "/vulnpy/cmdi/subprocess-popen", {"user_input": "echo attack"}
+    )
+    assert response.body == b"attack\n"
+
+
+def test_cmdi_subprocess_popen_bad_command(client):
+    client.get("/vulnpy/cmdi/subprocess-popen", {"user_input": "foo"}, status=400)
+
+
+def test_cmdi_subprocess_popen_invalid_input(client):
+    client.get("/vulnpy/cmdi/subprocess-popen", {"ignored_param": "bad"}, status=400)


### PR DESCRIPTION
# Changes
- provides the initial setup for including vulnpy endpoints in a Pyramid application
- adds basic cmdi endpoints for os.system and subprocess.Popen

# Notes
- we're already starting to see some duplication in the vulnpy testing suite. I'm brainstorming ways that we can write common tests - this will also ensure that the API exposed for all frameworks is exactly the same
- I have the corresponding apptests ready to go. As soon as this goes through I'll PR to the agent