### PR TITLE
PYT-896 Add Falcon cmdi

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Install vulnpy with flask extensions:
 pip install 'git+git://github.com/Contrast-Security-OSS/vulnpy#egg=vulnpy[flask]'
 ```
 
-When setting up your application, register the vulnerable blueprint to your `Flask`
-application object:
+When setting up your application, register the vulnerable blueprint to your `Flask` application
+object:
 
 ```py
 from vulnpy.flask import vulnerable_blueprint
@@ -42,4 +42,22 @@ During application configuration, include vulnpy's vulnerable routes:
 ```py
 config = Configurator()
 config.include("vulnpy.pyramid.vulnerable_routes", route_prefix="/vulnpy")
+```
+
+### Falcon
+
+Install vulnpy with falcon extensions:
+
+```
+pip install 'git+git://github.com/Contrast-Security-OSS/vulnpy#egg=vulnpy[falcon]'
+```
+
+Use the `add_vulnerable_routes` function to register vulnpy's routes with your `Falcon.API`
+application object:
+
+```py
+import vulnpy.falcon
+
+app = Falcon.API()
+vulnpy.falcon.add_vulnerable_routes(app)
 ```

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ django_extras = ["Django"]
 falcon_extras = ["falcon"]
 flask_extras = ["Flask"]
 pyramid_extras = ["pyramid"]
-testing_extras = ["WebTest"]
+testing_extras = ["mock==3.*", "WebTest"]
 all_extras = (
     django_extras + falcon_extras + flask_extras + pyramid_extras + testing_extras
 )

--- a/src/vulnpy/falcon/__init__.py
+++ b/src/vulnpy/falcon/__init__.py
@@ -1,0 +1,1 @@
+from .vulnerable import add_vulnerable_routes  # noqa: F401

--- a/src/vulnpy/falcon/vulnerable.py
+++ b/src/vulnpy/falcon/vulnerable.py
@@ -1,0 +1,41 @@
+from vulnpy.trigger import cmdi
+
+
+def add_vulnerable_routes(app):
+    app.add_route("/vulnpy", Home())
+    app.add_route("/vulnpy/cmdi/os-system", OsSystem())
+    app.add_route("/vulnpy/cmdi/subprocess-popen", SubprocessPopen())
+
+
+class Home(object):
+    def on_get(self, req, resp):
+        resp.body = "vulnpy root"
+
+
+class Cmdi(object):
+    def trigger(self):
+        raise NotImplementedError()
+
+    def on_get(self, req, resp):
+        user_input = req.get_param("user_input") or ""
+        catch_exception = req.get_param_as_bool("catch_exception")
+
+        if catch_exception:
+            try:
+                result = self.trigger(user_input)
+            except Exception as e:
+                result = str(e)
+        else:
+            result = self.trigger(user_input)
+
+        resp.body = result
+
+
+class OsSystem(Cmdi):
+    def trigger(self, command):
+        return str(cmdi.do_os_system(command))
+
+
+class SubprocessPopen(Cmdi):
+    def trigger(self, command):
+        return cmdi.do_subprocess_popen(command)

--- a/src/vulnpy/flask/blueprint.py
+++ b/src/vulnpy/flask/blueprint.py
@@ -5,11 +5,6 @@ from flask import Blueprint, request
 vulnerable_blueprint = Blueprint("vulnpy", __name__, url_prefix="/vulnpy")
 
 
-@vulnerable_blueprint.errorhandler(Exception)
-def _handle_exception(error):
-    return "something went wrong", 400
-
-
 @vulnerable_blueprint.route("/", methods=["GET", "POST"])
 def _home():
     return "vulnpy root"
@@ -25,12 +20,11 @@ def _cmdi_os_system():
 @vulnerable_blueprint.route("/cmdi/subprocess-popen/", methods=["GET", "POST"])
 def _cmdi_subprocess_popen():
     user_input = _get_user_input()
-    split_user_input = user_input.split()
-    output = cmdi.do_subprocess_popen(split_user_input)
+    output = cmdi.do_subprocess_popen(user_input)
     return output
 
 
 def _get_user_input():
     if request.method == "GET":
-        return request.args["user_input"]
-    return request.form["user_input"]
+        return request.args.get("user_input", "")
+    return request.form.get("user_input", "")

--- a/src/vulnpy/pyramid/vulnerable_routes.py
+++ b/src/vulnpy/pyramid/vulnerable_routes.py
@@ -15,11 +15,7 @@ def _cmdi_os_system(request):
 
 def _cmdi_subprocess_popen(request):
     user_input = _get_user_input(request)
-    split_user_input = user_input.split()
-    try:
-        output = cmdi.do_subprocess_popen(split_user_input)
-    except Exception as e:
-        return Response(str(e), 400)
+    output = cmdi.do_subprocess_popen(user_input)
     return Response(output)
 
 

--- a/src/vulnpy/trigger/cmdi.py
+++ b/src/vulnpy/trigger/cmdi.py
@@ -8,7 +8,7 @@ def do_os_system(command):
 
 def do_subprocess_popen(command):
     process = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True
     )
     stdout, _ = process.communicate()
     return stdout

--- a/tests/falcon/test_vulnerable.py
+++ b/tests/falcon/test_vulnerable.py
@@ -1,0 +1,81 @@
+import mock
+import pytest
+import falcon
+
+from falcon import testing
+
+import vulnpy
+import vulnpy.falcon
+
+
+@pytest.fixture
+def client():
+    app = falcon.API()
+    vulnpy.falcon.add_vulnerable_routes(app)
+    yield testing.TestClient(app)
+
+
+def test_home(client):
+    response = client.simulate_get("/vulnpy")
+    assert response.status_code == 200
+
+
+def test_cmdi_os_system_normal(client):
+    response = client.simulate_get(
+        "/vulnpy/cmdi/os-system", params={"user_input": "echo attack"}
+    )
+    assert int(response.content) == 0
+
+
+def test_cmdi_os_system_bad_command(client):
+    response = client.simulate_get(
+        "/vulnpy/cmdi/os-system", params={"user_input": "foo"}
+    )
+    assert int(response.content) != 0
+
+
+def test_cmdi_os_system_invalid_input(client):
+    response = client.simulate_get(
+        "/vulnpy/cmdi/os-system", params={"ignored_param": "bad"}
+    )
+    assert int(response.content) == 0
+    assert response.status_code == 200
+
+
+def test_cmdi_subprocess_popen_normal(client):
+    response = client.simulate_get(
+        "/vulnpy/cmdi/subprocess-popen", params={"user_input": "echo attack"}
+    )
+    assert response.content == b"attack\n"
+
+
+def test_cmdi_subprocess_popen_bad_command(client):
+    response = client.simulate_get(
+        "/vulnpy/cmdi/subprocess-popen", params={"user_input": "foo"}
+    )
+    assert response.status_code == 200
+
+
+def test_cmdi_subprocess_popen_invalid_input(client):
+    response = client.simulate_get(
+        "/vulnpy/cmdi/subprocess-popen", params={"ignored_param": "bad"}
+    )
+    assert response.status_code == 200
+
+
+@mock.patch(
+    "vulnpy.trigger.cmdi.do_os_system", side_effect=Exception("something bad happened")
+)
+def test_handle_exception(mocked_trigger, client):
+    response = client.simulate_get(
+        "/vulnpy/cmdi/os-system",
+        params={"user_input": "something", "catch_exception": True},
+    )
+    assert mocked_trigger.called
+    assert response.content == b"something bad happened"
+
+
+def test_cmdi_base_class():
+    handler = vulnpy.falcon.vulnerable.Cmdi()
+    with pytest.raises(NotImplementedError):
+        handler.trigger()

--- a/tests/flask/test_blueprint.py
+++ b/tests/flask/test_blueprint.py
@@ -36,7 +36,7 @@ def test_cmdi_os_system_bad_command(client):
 
 def test_cmdi_os_system_invalid_input(client):
     response = client.get("/vulnpy/cmdi/os-system/?ignored_param=bad")
-    assert response.status_code == 400
+    assert response.status_code == 200
 
 
 def test_cmdi_subprocess_popen_get(client):
@@ -53,9 +53,9 @@ def test_cmdi_subprocess_popen_post(client):
 
 def test_cmdi_subprocess_popen_bad_command(client):
     response = client.get("/vulnpy/cmdi/subprocess-popen/?user_input=foo")
-    assert response.status_code == 400
+    assert response.status_code == 200
 
 
 def test_cmdi_subprocess_popen_invalid_input(client):
     response = client.get("/vulnpy/cmdi/os-system/?ignored_param=bad")
-    assert response.status_code == 400
+    assert response.status_code == 200

--- a/tests/pyramid/test_vulnerable_routes.py
+++ b/tests/pyramid/test_vulnerable_routes.py
@@ -44,8 +44,8 @@ def test_cmdi_subprocess_popen_normal(client, method_name):
 
 
 def test_cmdi_subprocess_popen_bad_command(client):
-    client.get("/vulnpy/cmdi/subprocess-popen", {"user_input": "foo"}, status=400)
+    client.get("/vulnpy/cmdi/subprocess-popen", {"user_input": "foo"}, status=200)
 
 
 def test_cmdi_subprocess_popen_invalid_input(client):
-    client.get("/vulnpy/cmdi/subprocess-popen", {"ignored_param": "bad"}, status=400)
+    client.get("/vulnpy/cmdi/subprocess-popen", {"ignored_param": "bad"}, status=200)

--- a/tests/trigger/test_cmdi.py
+++ b/tests/trigger/test_cmdi.py
@@ -17,12 +17,12 @@ def test_do_os_system_exception():
 
 
 def test_do_subprocess_popen():
-    assert cmdi.do_subprocess_popen(["echo", "hacked"]) == b"hacked\n"
+    assert cmdi.do_subprocess_popen("echo hacked") == b"hacked\n"
 
 
 def test_do_subprocess_popen_bad_command():
-    with pytest.raises(OSError):
-        cmdi.do_subprocess_popen(["foooooooo", "this", "is", "not", "a", "command"])
+    """This makes some assumptions about the host system, but it seems to be generic enough"""
+    assert b"not found" in cmdi.do_subprocess_popen("foooooooo this is not a command")
 
 
 def test_do_subprocess_popen_exception():


### PR DESCRIPTION
# Overview
- This contains the skeleton for pluggable falcon endpoints. Falcon doesn't have a blueprint-like functionality like most other frameworks, so I created a function in `vulnpy` for adding our routes to the falcon app.
- Added cmdi falcon routes

# Extras
- based on some of the code from the falcon apptests, I was able to greatly simplify subprocess.Popen error handling in all frameworks. Basically, now we're using the `shell` mode for this trigger
- adds `mock` as a testing dependency