### PR TITLE
Pyt 897 add templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .tox
 .pytest_cache
 .coverage.*
+.coverage
 
 # python
 *.pyc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to VulnPy
+
+## Dev Environment Setup
+
+We recommend entering a virtual environment and performing an editable install of this package with
+all extra dependencies. Once in a virtualenv, run:
+
+```sh
+pip install -e '.[all]'
+```
+
+## Regenerating Templates
+
+For maximum portability, the HTML returned by vulnpy endpoints does not require additional
+rendering by a template engine. To achieve this with minimal code duplication, we generate all
+HTML statically.
+
+To modify existing templates, change or add HTML fragments in `vulnpy/templates/fragments`. Each
+`*.frag.html` is spliced into the `base.html` skeleton. To regenerate templates, simply run:
+
+```sh
+make
+```
+
+Generated templates must be committed to this repository and will ship with the installed python
+package for vulnpy.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/vulnpy/templates/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+templates:
+	./scripts/gen_templates.sh
+
+flask: templates
+	FLASK_APP=apps/flask_app.py flask run --port=8000
+
+falcon: templates
+	gunicorn apps.falcon_app:app
+
+pyramid: templates
+	python apps/pyramid_app.py
+
+django: templates
+	python apps/django_app.py runserver

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ During application configuration, include vulnpy's vulnerable routes:
 
 ```py
 config = Configurator()
-config.include("vulnpy.pyramid.vulnerable_routes", route_prefix="/vulnpy")
+config.include("vulnpy.pyramid.vulnerable_routes")
 ```
 
 ### Falcon
@@ -84,3 +84,20 @@ import vulnpy.falcon
 app = Falcon.API()
 vulnpy.falcon.add_vulnerable_routes(app)
 ```
+
+## Sample Servers
+
+`vulnpy` is intended to extend the functionality of an existing web application. However, for
+convenience, we provide tiny webapps for each supported framework with `vulnpy` attached.
+
+To serve a webapp on your local machine,
+- check out the source repo and `cd` into it
+- ensure that vulnpy is installed in your current virtual environment with the appropriate extensions (see above)
+- run:
+
+```sh
+make (your_framework)
+```
+
+For example, `pip install -e ".[flask]" && make flask` launches a simple flask webapp with vulnpy
+endpoints.

--- a/apps/django_app.py
+++ b/apps/django_app.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+from django.conf import settings
+from django.core.management import execute_from_command_line
+from django.shortcuts import redirect
+
+try:
+    from django.urls import re_path as compat_url
+except ImportError:
+    from django.conf.urls import url as compat_url
+
+from vulnpy.django import vulnerable_urlpatterns
+
+
+urlpatterns = [
+    compat_url(r"^$", lambda r: redirect("/vulnpy"))
+] + vulnerable_urlpatterns
+
+filename = os.path.basename(os.path.splitext(__file__)[0])
+
+if __name__ == "__main__":
+    settings.configure(ROOT_URLCONF=filename, ALLOWED_HOSTS="localhost")
+    execute_from_command_line(sys.argv)

--- a/apps/falcon_app.py
+++ b/apps/falcon_app.py
@@ -1,0 +1,12 @@
+import falcon
+import vulnpy.falcon
+
+
+class Index(object):
+    def on_get(self, req, resp):
+        raise falcon.HTTPFound("/vulnpy")
+
+
+app = falcon.API()
+vulnpy.falcon.add_vulnerable_routes(app)
+app.add_route("/", Index())

--- a/apps/flask_app.py
+++ b/apps/flask_app.py
@@ -1,0 +1,11 @@
+from flask import Flask, redirect
+
+from vulnpy.flask.blueprint import vulnerable_blueprint
+
+app = Flask(__name__)
+app.register_blueprint(vulnerable_blueprint)
+
+
+@app.route("/")
+def index():
+    return redirect("/vulnpy/")

--- a/apps/pyramid_app.py
+++ b/apps/pyramid_app.py
@@ -1,0 +1,16 @@
+from pyramid.config import Configurator
+from pyramid.httpexceptions import HTTPFound
+from waitress import serve
+
+
+def index(request):
+    return HTTPFound(location="/vulnpy")
+
+
+if __name__ == "__main__":
+    with Configurator() as config:
+        config.include("vulnpy.pyramid.vulnerable_routes")
+        config.add_route("index", "/")
+        config.add_view(index, route_name="index")
+        app = config.make_wsgi_app()
+    serve(app, host="localhost", port=8000)

--- a/scripts/gen_templates.sh
+++ b/scripts/gen_templates.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eu
+
+cd $(dirname ${BASH_SOURCE})/../src/vulnpy/templates/fragments
+
+for fragment in *.frag.html; do
+	pagename=${fragment%.frag.html}.html
+	outfilename=../$pagename
+	echo "<!-- This file was automatically generated. Do not edit manually. -->" > ${outfilename}
+	sed -e "/###vulnpy-injection-site###/r${fragment}" base.html >> ${outfilename}
+	echo "wrote $pagename"
+done

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ django_extras = ["Django"]
 falcon_extras = ["falcon"]
 flask_extras = ["Flask"]
 pyramid_extras = ["pyramid"]
-testing_extras = ["mock==3.*", "WebTest"]
+extra_extras = ["mock==3.*", "WebTest", "gunicorn"]
 all_extras = (
-    django_extras + falcon_extras + flask_extras + pyramid_extras + testing_extras
+    django_extras + falcon_extras + flask_extras + pyramid_extras + extra_extras
 )
 
 setup(
@@ -41,6 +41,7 @@ setup(
     author_email="python@contrastsecurity.onmicrosoft.com",
     url="https://github.com/Contrast-Security-OSS/vulnpy",
     license="MIT",
+    include_package_data=True,
     packages=find_packages("src"),
     package_dir={"": "src"},
     python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",

--- a/src/vulnpy/common/__init__.py
+++ b/src/vulnpy/common/__init__.py
@@ -1,1 +1,1 @@
-from .utils import get_template  # noqa: F401
+from .templating import get_template  # noqa: F401

--- a/src/vulnpy/common/__init__.py
+++ b/src/vulnpy/common/__init__.py
@@ -1,0 +1,1 @@
+from .utils import get_template  # noqa: F401

--- a/src/vulnpy/common/templating.py
+++ b/src/vulnpy/common/templating.py
@@ -5,6 +5,18 @@ import vulnpy
 TEMPLATES_LOCATION = os.path.join(os.path.dirname(vulnpy.__file__), "templates")
 
 
+def cache(func):
+    cache = {}
+
+    def wrapper(*args):
+        if args not in cache:
+            cache[args] = func(*args)
+        return cache[args]
+
+    return wrapper
+
+
+@cache
 def get_template(path):
     """
     Read and return the contents of the file at TEMPLATES_LOCATON/<path>.

--- a/src/vulnpy/common/utils.py
+++ b/src/vulnpy/common/utils.py
@@ -1,0 +1,16 @@
+import os
+
+import vulnpy
+
+TEMPLATES_LOCATION = os.path.join(os.path.dirname(vulnpy.__file__), "templates")
+
+
+def get_template(path):
+    """
+    Read and return the contents of the file at TEMPLATES_LOCATON/<path>.
+    This is vulnerable to path traversal if used incorrectly, but security clearly
+    isn't a concern if you're using `vulnpy`.
+    """
+    filename = os.path.join(TEMPLATES_LOCATION, path)
+    with open(filename, "r") as f:
+        return f.read()

--- a/src/vulnpy/django/vulnerable.py
+++ b/src/vulnpy/django/vulnerable.py
@@ -1,27 +1,32 @@
-from vulnpy.trigger import cmdi
+from django.http import HttpResponse
 
 try:
     from django.urls import re_path as compat_url
 except ImportError:
     from django.conf.urls import url as compat_url
 
-from django.http import HttpResponse
+from vulnpy.common import get_template
+from vulnpy.trigger import cmdi
 
 
 def _vulnpy_root(request):
-    return HttpResponse("vulnpy root")
+    return HttpResponse(get_template("home.html"))
+
+
+def _cmdi(request):
+    return HttpResponse(get_template("cmdi.html"))
 
 
 def _cmdi_os_system(request):
     user_input = _get_user_input(request)
-    status = cmdi.do_os_system(user_input)
-    return HttpResponse(str(status))
+    cmdi.do_os_system(user_input)
+    return HttpResponse(get_template("cmdi.html"))
 
 
 def _cmdi_subprocess_popen(request):
     user_input = _get_user_input(request)
-    output = cmdi.do_subprocess_popen(user_input)
-    return HttpResponse(output)
+    cmdi.do_subprocess_popen(user_input)
+    return HttpResponse(get_template("cmdi.html"))
 
 
 def _get_user_input(request):
@@ -32,6 +37,7 @@ def _get_user_input(request):
 
 vulnerable_urlpatterns = [
     compat_url(r"^vulnpy/?$", _vulnpy_root),
+    compat_url(r"^vulnpy/cmdi/?$", _cmdi),
     compat_url(r"^vulnpy/cmdi/os-system/?$", _cmdi_os_system),
     compat_url(r"^vulnpy/cmdi/subprocess-popen/?$", _cmdi_subprocess_popen),
 ]

--- a/src/vulnpy/falcon/vulnerable.py
+++ b/src/vulnpy/falcon/vulnerable.py
@@ -1,20 +1,37 @@
+from vulnpy.common import get_template
 from vulnpy.trigger import cmdi
 
 
 def add_vulnerable_routes(app):
+    """
+    Add vulnpy's routes to the provided falcon app.
+    Also enables stripping of trailing URL slashes for the entire application.
+    This means that /foo/bar and /foo/bar/ will resolve to the same handler.
+    :param app: instance of falcon.API
+    """
+    app.req_options.strip_url_path_trailing_slash = True
     app.add_route("/vulnpy", Home())
+    app.add_route("/vulnpy/cmdi", Cmdi())
     app.add_route("/vulnpy/cmdi/os-system", OsSystem())
     app.add_route("/vulnpy/cmdi/subprocess-popen", SubprocessPopen())
 
 
+def _set_response(resp, path):
+    """
+    Set the response body and Content-Type
+    """
+    resp.body = get_template(path)
+    resp.content_type = "text/html"
+
+
 class Home(object):
     def on_get(self, req, resp):
-        resp.body = "vulnpy root"
+        _set_response(resp, "home.html")
 
 
 class Cmdi(object):
-    def trigger(self):
-        raise NotImplementedError()
+    def trigger(self, command):
+        pass
 
     def on_get(self, req, resp):
         user_input = req.get_param("user_input") or ""
@@ -22,20 +39,20 @@ class Cmdi(object):
 
         if catch_exception:
             try:
-                result = self.trigger(user_input)
-            except Exception as e:
-                result = str(e)
+                self.trigger(user_input)
+            except Exception:
+                pass
         else:
-            result = self.trigger(user_input)
+            self.trigger(user_input)
 
-        resp.body = result
+        _set_response(resp, "cmdi.html")
 
 
 class OsSystem(Cmdi):
     def trigger(self, command):
-        return str(cmdi.do_os_system(command))
+        cmdi.do_os_system(command)
 
 
 class SubprocessPopen(Cmdi):
     def trigger(self, command):
-        return cmdi.do_subprocess_popen(command)
+        cmdi.do_subprocess_popen(command)

--- a/src/vulnpy/flask/blueprint.py
+++ b/src/vulnpy/flask/blueprint.py
@@ -1,27 +1,37 @@
-from vulnpy.trigger import cmdi
-
 from flask import Blueprint, request
 
-vulnerable_blueprint = Blueprint("vulnpy", __name__, url_prefix="/vulnpy")
+from vulnpy.common import get_template
+from vulnpy.trigger import cmdi
+
+vulnerable_blueprint = Blueprint("vulnpy", __name__, url_prefix="/vulnpy",)
 
 
-@vulnerable_blueprint.route("/", methods=["GET", "POST"])
+@vulnerable_blueprint.route("/", methods=["GET", "POST"], strict_slashes=False)
 def _home():
-    return "vulnpy root"
+    return get_template("home.html")
 
 
-@vulnerable_blueprint.route("/cmdi/os-system/", methods=["GET", "POST"])
+@vulnerable_blueprint.route("/cmdi/", methods=["GET", "POST"], strict_slashes=False)
+def _cmdi():
+    return get_template("cmdi.html")
+
+
+@vulnerable_blueprint.route(
+    "/cmdi/os-system/", methods=["GET", "POST"], strict_slashes=False
+)
 def _cmdi_os_system():
     user_input = _get_user_input()
-    status = cmdi.do_os_system(user_input)
-    return str(status)
+    cmdi.do_os_system(user_input)
+    return get_template("cmdi.html")
 
 
-@vulnerable_blueprint.route("/cmdi/subprocess-popen/", methods=["GET", "POST"])
+@vulnerable_blueprint.route(
+    "/cmdi/subprocess-popen/", methods=["GET", "POST"], strict_slashes=False
+)
 def _cmdi_subprocess_popen():
     user_input = _get_user_input()
-    output = cmdi.do_subprocess_popen(user_input)
-    return output
+    cmdi.do_subprocess_popen(user_input)
+    return get_template("cmdi.html")
 
 
 def _get_user_input():

--- a/src/vulnpy/templates/cmdi.html
+++ b/src/vulnpy/templates/cmdi.html
@@ -1,0 +1,62 @@
+<!-- This file was automatically generated. Do not edit manually. -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.2/css/bulma.min.css">
+  </head>
+  <body>
+    <nav class="navbar" style="background: #4b8bbe">
+      <div class="navbar-brand">
+        <a class="navbar-item" href="/vulnpy/">
+          VulnPy by Contrast Security
+        </a>
+      </div>
+    </nav>
+    <div class="columns">
+      <aside class="column is-2 hero aside is-fullheight" style="background: #ffe873">
+        <div>
+          <div class="main">
+            <ul class="menu-list">
+              <li><a href="/vulnpy/cmdi/">CMD Injection</a></li>
+            </ul>
+          </div>
+        </div>
+      </aside>
+      <br>
+      <div class="column container">
+        <!-- ###vulnpy-injection-site### - do not modify this line; it's in a regex -->
+<h1>Cmd Injection: os.system</h1>
+
+<form action="/vulnpy/cmdi/os-system/" method="get">
+  <div class="field has-addons">
+    <div class="control">
+      <input class="input" type="text" name="user_input" placeholder="ls; echo hacked">
+    </div>
+    <div class="control">
+      <button class="button is-info" action="submit">
+        Execute
+      </button>
+    </div>
+  </div>
+</form>
+<br>
+
+<h1>Cmd Injection: subprocess.popen</h1>
+
+<form action="/vulnpy/cmdi/subprocess-popen/" method="get">
+  <div class="field has-addons">
+    <div class="control">
+      <input class="input" type="text" name="user_input" placeholder="ls; echo hacked">
+    </div>
+    <div class="control">
+      <button class="button is-info" action="submit">
+        Execute
+      </button>
+    </div>
+  </div>
+</form>
+        <!-- post-injection site -->
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/vulnpy/templates/fragments/base.html
+++ b/src/vulnpy/templates/fragments/base.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.2/css/bulma.min.css">
+  </head>
+  <body>
+    <nav class="navbar" style="background: #4b8bbe">
+      <div class="navbar-brand">
+        <a class="navbar-item" href="/vulnpy/">
+          VulnPy by Contrast Security
+        </a>
+      </div>
+    </nav>
+    <div class="columns">
+      <aside class="column is-2 hero aside is-fullheight" style="background: #ffe873">
+        <div>
+          <div class="main">
+            <ul class="menu-list">
+              <li><a href="/vulnpy/cmdi/">CMD Injection</a></li>
+            </ul>
+          </div>
+        </div>
+      </aside>
+      <br>
+      <div class="column container">
+        <!-- ###vulnpy-injection-site### - do not modify this line; it's in a regex -->
+        <!-- post-injection site -->
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/vulnpy/templates/fragments/cmdi.frag.html
+++ b/src/vulnpy/templates/fragments/cmdi.frag.html
@@ -1,0 +1,30 @@
+<h1>Cmd Injection: os.system</h1>
+
+<form action="/vulnpy/cmdi/os-system/" method="get">
+  <div class="field has-addons">
+    <div class="control">
+      <input class="input" type="text" name="user_input" placeholder="ls; echo hacked">
+    </div>
+    <div class="control">
+      <button class="button is-info" action="submit">
+        Execute
+      </button>
+    </div>
+  </div>
+</form>
+<br>
+
+<h1>Cmd Injection: subprocess.popen</h1>
+
+<form action="/vulnpy/cmdi/subprocess-popen/" method="get">
+  <div class="field has-addons">
+    <div class="control">
+      <input class="input" type="text" name="user_input" placeholder="ls; echo hacked">
+    </div>
+    <div class="control">
+      <button class="button is-info" action="submit">
+        Execute
+      </button>
+    </div>
+  </div>
+</form>

--- a/src/vulnpy/templates/fragments/home.frag.html
+++ b/src/vulnpy/templates/fragments/home.frag.html
@@ -1,0 +1,2 @@
+<h1>Welcome</h1>
+<p>This is the Contrast Security engine for testing vulnerable methods</p>

--- a/src/vulnpy/templates/home.html
+++ b/src/vulnpy/templates/home.html
@@ -1,0 +1,34 @@
+<!-- This file was automatically generated. Do not edit manually. -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.2/css/bulma.min.css">
+  </head>
+  <body>
+    <nav class="navbar" style="background: #4b8bbe">
+      <div class="navbar-brand">
+        <a class="navbar-item" href="/vulnpy/">
+          VulnPy by Contrast Security
+        </a>
+      </div>
+    </nav>
+    <div class="columns">
+      <aside class="column is-2 hero aside is-fullheight" style="background: #ffe873">
+        <div>
+          <div class="main">
+            <ul class="menu-list">
+              <li><a href="/vulnpy/cmdi/">CMD Injection</a></li>
+            </ul>
+          </div>
+        </div>
+      </aside>
+      <br>
+      <div class="column container">
+        <!-- ###vulnpy-injection-site### - do not modify this line; it's in a regex -->
+<h1>Welcome</h1>
+<p>This is the Contrast Security engine for testing vulnerable methods</p>
+        <!-- post-injection site -->
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/django/test_vulnerable.py
+++ b/tests/django/test_vulnerable.py
@@ -16,21 +16,25 @@ def test_vulnpy_root(client):
     assert response.status_code == 200
 
 
+def test_cmdi_basic(client):
+    response = client.get("/vulnpy/cmdi")
+    assert response.status_code == 200
+
+
 @pytest.mark.parametrize("method_name", ["get", "post"])
 def test_cmdi_os_system_normal(client, method_name):
     get_or_post = getattr(client, method_name)
     response = get_or_post("/vulnpy/cmdi/os-system", {"user_input": "echo attack"})
-    assert int(response.content) == 0
+    assert response.status_code == 200
 
 
 def test_cmdi_os_system_bad_command(client):
     response = client.get("/vulnpy/cmdi/os-system", {"user_input": "foo"})
-    assert int(response.content) != 0
+    assert response.status_code == 200
 
 
 def test_cmdi_os_system_invalid_input(client):
     response = client.get("/vulnpy/cmdi/os-system", {"ignored_param": "bad"})
-    assert int(response.content) == 0
     assert response.status_code == 200
 
 
@@ -40,7 +44,7 @@ def test_cmdi_subprocess_popen_normal(client, method_name):
     response = get_or_post(
         "/vulnpy/cmdi/subprocess-popen", {"user_input": "echo attack"}
     )
-    assert response.content == b"attack\n"
+    assert response.status_code == 200
 
 
 def test_cmdi_subprocess_popen_bad_command(client):

--- a/tests/falcon/test_vulnerable.py
+++ b/tests/falcon/test_vulnerable.py
@@ -20,25 +20,29 @@ def test_home(client):
     assert response.status_code == 200
 
 
+def test_cmdi_basic(client):
+    response = client.simulate_get("/vulnpy/cmdi")
+    assert response.status_code == 200
+
+
 def test_cmdi_os_system_normal(client):
     response = client.simulate_get(
         "/vulnpy/cmdi/os-system", params={"user_input": "echo attack"}
     )
-    assert int(response.content) == 0
+    assert response.status_code == 200
 
 
 def test_cmdi_os_system_bad_command(client):
     response = client.simulate_get(
         "/vulnpy/cmdi/os-system", params={"user_input": "foo"}
     )
-    assert int(response.content) != 0
+    assert response.status_code == 200
 
 
 def test_cmdi_os_system_invalid_input(client):
     response = client.simulate_get(
         "/vulnpy/cmdi/os-system", params={"ignored_param": "bad"}
     )
-    assert int(response.content) == 0
     assert response.status_code == 200
 
 
@@ -46,7 +50,7 @@ def test_cmdi_subprocess_popen_normal(client):
     response = client.simulate_get(
         "/vulnpy/cmdi/subprocess-popen", params={"user_input": "echo attack"}
     )
-    assert response.content == b"attack\n"
+    assert response.status_code == 200
 
 
 def test_cmdi_subprocess_popen_bad_command(client):
@@ -72,10 +76,4 @@ def test_handle_exception(mocked_trigger, client):
         params={"user_input": "something", "catch_exception": True},
     )
     assert mocked_trigger.called
-    assert response.content == b"something bad happened"
-
-
-def test_cmdi_base_class():
-    handler = vulnpy.falcon.vulnerable.Cmdi()
-    with pytest.raises(NotImplementedError):
-        handler.trigger()
+    assert response.status_code == 200

--- a/tests/flask/test_blueprint.py
+++ b/tests/flask/test_blueprint.py
@@ -17,21 +17,26 @@ def test_home(client):
     assert response.status_code == 200
 
 
+def test_cmdi_basic(client):
+    response = client.get("/vulnpy/cmdi")
+    assert response.status_code == 200
+
+
 def test_cmdi_os_system_get(client):
     response = client.get("/vulnpy/cmdi/os-system/?user_input=echo%20attack")
-    assert int(response.get_data()) == 0
+    assert response.status_code == 200
 
 
 def test_cmdi_os_system_post(client):
     response = client.post(
         "/vulnpy/cmdi/os-system/", data={"user_input": "echo attack"}
     )
-    assert int(response.get_data()) == 0
+    assert response.status_code == 200
 
 
 def test_cmdi_os_system_bad_command(client):
     response = client.get("/vulnpy/cmdi/os-system/?user_input=foo")
-    assert int(response.get_data()) != 0
+    assert response.status_code == 200
 
 
 def test_cmdi_os_system_invalid_input(client):
@@ -41,14 +46,14 @@ def test_cmdi_os_system_invalid_input(client):
 
 def test_cmdi_subprocess_popen_get(client):
     response = client.get("/vulnpy/cmdi/subprocess-popen/?user_input=echo%20attack")
-    assert response.get_data() == b"attack\n"
+    assert response.status_code == 200
 
 
 def test_cmdi_subprocess_popen_post(client):
     response = client.post(
         "/vulnpy/cmdi/subprocess-popen/", data={"user_input": "echo attack"}
     )
-    assert response.get_data() == b"attack\n"
+    assert response.status_code == 200
 
 
 def test_cmdi_subprocess_popen_bad_command(client):


### PR DESCRIPTION
### Major Changes
- Added HTML responses to all endpoints
  - The HTML does not require a template engine, so it is fully reusable across apps
  - caveat: we can't make use of code deduplication that comes naturally from templates - instead we're auto-generating full HTML pages using HTML fragments. These fragments are partial webpages that are spliced into the master navigation template using `make`
- Added tiny (single-file!) webapps for each supported framework
  - These tiny apps can be served using `make (flask|falcon|pyramid|pylons)`
  - This leads naturally into display apps, etc. I hope to dockerize them eventually.

### Minor Changes
- Slightly changed the way we add vulnpy to pyramid applications
  - This is a breaking change, and I have the agent PR ready with all tests passing locally
  - as soon as this is merged, I will open the corresponding PR
- Added logic to ensure that for all frameworks, any URI can be accessed with or without a trailing slash. This was... surprisingly difficult
- Updated some packaging / documentation things
- Updated unit tests accordingly. I opened a ticket for total unit test deduplication, because they're getting reeeeeealllly similar now

![image](https://user-images.githubusercontent.com/6841750/90563471-de93be80-e171-11ea-8a5a-51816f0ddfbc.png)
