### PR TITLE
PYT-898 PYT-899 PYT-900 PYT-901 Set up sample apps for screener

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
+HOST ?= localhost
+PORT ?= 8000
+
 templates:
 	./scripts/gen_templates.sh
 
 flask: templates
-	FLASK_APP=apps/flask_app.py flask run --port=8000
+	FLASK_APP=apps/flask_app.py flask run --host=$(HOST) --port=$(PORT)
 
 falcon: templates
-	gunicorn apps.falcon_app:app
+	gunicorn -b $(HOST):$(PORT) apps.falcon_app:app
 
 pyramid: templates
-	python apps/pyramid_app.py
+	python apps/pyramid_app.py $(HOST):$(PORT)
 
 django: templates
-	python apps/django_app.py runserver
+	python apps/django_app.py runserver $(HOST):$(PORT)

--- a/apps/django_app.py
+++ b/apps/django_app.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+import django
 from django.conf import settings
 from django.core.management import execute_from_command_line
 from django.shortcuts import redirect
@@ -20,5 +21,24 @@ urlpatterns = [
 filename = os.path.basename(os.path.splitext(__file__)[0])
 
 if __name__ == "__main__":
-    settings.configure(ROOT_URLCONF=filename, ALLOWED_HOSTS="localhost")
+
+    options = {
+        "ROOT_URLCONF": filename,
+        "ALLOWED_HOSTS": ["localhost", "127.0.0.1", "[::1]"],
+    }
+
+    if os.environ.get("VULNPY_USE_CONTRAST"):
+        if django.VERSION < (1, 10):
+            middleware_setting_name = "MIDDLEWARE_CLASSES"
+            contrast_middleware_name = (
+                "contrast.agent.middlewares.legacy_django_middleware.DjangoMiddleware"
+            )
+        else:
+            middleware_setting_name = "MIDDLEWARE"
+            contrast_middleware_name = (
+                "contrast.agent.middlewares.django_middleware.DjangoMiddleware"
+            )
+        options[middleware_setting_name] = [contrast_middleware_name]
+
+    settings.configure(**options)
     execute_from_command_line(sys.argv)

--- a/apps/falcon_app.py
+++ b/apps/falcon_app.py
@@ -1,3 +1,5 @@
+import os
+
 import falcon
 import vulnpy.falcon
 
@@ -10,3 +12,10 @@ class Index(object):
 app = falcon.API()
 vulnpy.falcon.add_vulnerable_routes(app)
 app.add_route("/", Index())
+
+if os.environ.get("VULNPY_USE_CONTRAST"):
+    from contrast.agent.middlewares.wsgi_middleware import (
+        WSGIMiddleware as ContrastMiddleware,
+    )
+
+    app = ContrastMiddleware(app)

--- a/apps/flask_app.py
+++ b/apps/flask_app.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask, redirect
 
 from vulnpy.flask.blueprint import vulnerable_blueprint
@@ -9,3 +11,11 @@ app.register_blueprint(vulnerable_blueprint)
 @app.route("/")
 def index():
     return redirect("/vulnpy/")
+
+
+if os.environ.get("VULNPY_USE_CONTRAST"):
+    from contrast.agent.middlewares.flask_middleware import (
+        FlaskMiddleware as ContrastMiddleware,
+    )
+
+    app.wsgi_app = ContrastMiddleware(app)

--- a/apps/pyramid_app.py
+++ b/apps/pyramid_app.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 from pyramid.config import Configurator
 from pyramid.httpexceptions import HTTPFound
 from waitress import serve
@@ -8,9 +11,17 @@ def index(request):
 
 
 if __name__ == "__main__":
+    host, port = sys.argv[1].split(":")
     with Configurator() as config:
         config.include("vulnpy.pyramid.vulnerable_routes")
         config.add_route("index", "/")
         config.add_view(index, route_name="index")
+
+        if os.environ.get("VULNPY_USE_CONTRAST"):
+            config.add_tween(
+                "contrast.agent.middlewares.pyramid_middleware.PyramidMiddleware"
+            )
+
         app = config.make_wsgi_app()
-    serve(app, host="localhost", port=8000)
+
+    serve(app, host=host, port=int(port))


### PR DESCRIPTION
*Minor adjustments to make vulnpy sample apps compatible with screener*

## Changes
- Added the ability to start each sample app with contrast enabled
  - This is controlled by setting `VULNPY_USE_CONTRAST`
- Added the ability to customize host and port for each app
  - For example: `make flask HOST=0.0.0.0 PORT=7000`