### PR TITLE
Automate generating framework endpoints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,17 +17,13 @@ frameworks when a new trigger is added. To add a new trigger:
 1. Add a new file under trigger/ if the vulnerability you are adding doesn't have one
  already
  
-2. Add "do_vulnname_triggername" function in the vulnerability file. Note the 
-function definition must be prefixed with "do_".
+2. Add "do_vulnname_triggername" function in the vulnerability file. **Note the 
+function definition must be prefixed with "do_".**
 
-3. Add trigger name to TRIGGER_MAP. Note that at this time Vulnpy makes some 
-assumptions about the 
-trigger name strings so you may need to modify this string to use underscores or dashes.
-
-4. Add a new file under templates/fragments/vulnname.frag.html OR use the existing 
+3. Add a new file under templates/fragments/vulnname.frag.html OR use the existing 
 one to add a new fragment for the trigger. This step may be automated in the future.
 
-5. Add tests under trigger/ and for each of the frameworks to call the new trigger.
+4. Add tests under trigger/ and for each of the frameworks to call the new trigger.
 
 
 ## Regenerating Templates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,27 @@ all extra dependencies. Once in a virtualenv, run:
 pip install -e '.[all]'
 ```
 
+## Adding New Triggers
+
+Vulnpy is able to automatically generate view definitions for all supported 
+frameworks when a new trigger is added. To add a new trigger:
+
+1. Add a new file under trigger/ if the vulnerability you are adding doesn't have one
+ already
+ 
+2. Add "do_vulnname_triggername" function in the vulnerability file. Note the 
+function definition must be prefixed with "do_".
+
+3. Add trigger name to TRIGGER_MAP. Note that at this time Vulnpy makes some 
+assumptions about the 
+trigger name strings so you may need to modify this string to use underscores or dashes.
+
+4. Add a new file under templates/fragments/vulnname.frag.html OR use the existing 
+one to add a new fragment for the trigger. This step may be automated in the future.
+
+5. Add tests under trigger/ and for each of the frameworks to call the new trigger.
+
+
 ## Regenerating Templates
 
 For maximum portability, the HTML returned by vulnpy endpoints does not require additional

--- a/src/vulnpy/django/vulnerable.py
+++ b/src/vulnpy/django/vulnerable.py
@@ -29,10 +29,14 @@ def get_trigger_view(name, trigger):
         user_input = _get_user_input(request)
 
         module = sys.modules.get("vulnpy.trigger.{}".format(name))
+        if not module:
+            raise RuntimeError("Please import trigger module {} at the top of {}".format(name, __file__))
+
         trigger_func = get_trigger(module, trigger)
 
         if trigger_func:
             trigger_func(user_input)
+
         return HttpResponse(get_template("{}.html".format(name)))
 
     return _view

--- a/src/vulnpy/django/vulnerable.py
+++ b/src/vulnpy/django/vulnerable.py
@@ -1,5 +1,3 @@
-import sys
-
 from django.http import HttpResponse
 
 try:
@@ -8,7 +6,7 @@ except ImportError:
     from django.conf.urls import url as compat_url
 
 from vulnpy.common import get_template
-from vulnpy.trigger import TRIGGER_MAP, get_trigger, cmdi, deserialization  # noqa: F401
+from vulnpy.trigger import TRIGGER_MAP, get_trigger
 
 
 def _get_user_input(request):
@@ -27,16 +25,7 @@ def gen_root_view(name):
 def get_trigger_view(name, trigger):
     def _view(request):
         user_input = _get_user_input(request)
-
-        module = sys.modules.get("vulnpy.trigger.{}".format(name))
-        if not module:
-            raise RuntimeError(
-                "Please import trigger module {} at the top of {}".format(
-                    name, __file__
-                )
-            )
-
-        trigger_func = get_trigger(module, trigger)
+        trigger_func = get_trigger(name, trigger)
 
         if trigger_func:
             trigger_func(user_input)

--- a/src/vulnpy/django/vulnerable.py
+++ b/src/vulnpy/django/vulnerable.py
@@ -8,7 +8,7 @@ except ImportError:
     from django.conf.urls import url as compat_url
 
 from vulnpy.common import get_template
-from vulnpy.trigger import TRIGGER_MAP, cmdi, deserialization  # noqa: F401
+from vulnpy.trigger import TRIGGER_MAP, get_trigger, cmdi, deserialization  # noqa: F401
 
 
 def _get_user_input(request):
@@ -22,22 +22,6 @@ def gen_root_view(name):
         return HttpResponse(get_template("{}.html".format(name)))
 
     return _root
-
-
-def get_trigger(module, trigger_name):
-    """
-    Find a function LIKE trigger_name in the module.
-
-    :param module: Python module
-    :param trigger_name: str
-    :return: function
-    """
-    func_name = "do_{}".format(trigger_name.replace("-", "_"))
-
-    try:
-        return getattr(module, func_name)
-    except AttributeError:
-        return
 
 
 def get_trigger_view(name, trigger):

--- a/src/vulnpy/django/vulnerable.py
+++ b/src/vulnpy/django/vulnerable.py
@@ -30,7 +30,11 @@ def get_trigger_view(name, trigger):
 
         module = sys.modules.get("vulnpy.trigger.{}".format(name))
         if not module:
-            raise RuntimeError("Please import trigger module {} at the top of {}".format(name, __file__))
+            raise RuntimeError(
+                "Please import trigger module {} at the top of {}".format(
+                    name, __file__
+                )
+            )
 
         trigger_func = get_trigger(module, trigger)
 

--- a/src/vulnpy/falcon/vulnerable.py
+++ b/src/vulnpy/falcon/vulnerable.py
@@ -1,7 +1,7 @@
 import inspect
 import sys
 from vulnpy.common import get_template
-from vulnpy.trigger import TRIGGER_MAP, get_trigger, cmdi, deserialization  # noqa: F401
+from vulnpy.trigger import TRIGGER_MAP, get_trigger
 
 
 def get_root_name(name):
@@ -64,8 +64,7 @@ def get_trigger_view(name, trigger):
 
     class _View(baseclass):
         def trigger(self, command):
-            module = sys.modules.get("vulnpy.trigger.{}".format(name))
-            trigger_func = get_trigger(module, trigger)
+            trigger_func = get_trigger(name, trigger)
 
             if trigger_func:
                 trigger_func(command)

--- a/src/vulnpy/falcon/vulnerable.py
+++ b/src/vulnpy/falcon/vulnerable.py
@@ -1,5 +1,98 @@
+import inspect
+import sys
 from vulnpy.common import get_template
-from vulnpy.trigger import cmdi, deserialization
+from vulnpy.trigger import TRIGGER_MAP, get_trigger, cmdi, deserialization  # noqa: F401
+
+
+def get_root_name(name):
+    if name == "home":
+        return "/vulnpy"
+    return "/vulnpy/{}".format(name)
+
+
+def get_trigger_name(name, trigger):
+    return "/vulnpy/{}/{}".format(name, trigger)
+
+
+def gen_root_view(name):  # noqa: C901
+    if name == "home":
+
+        class _View(object):
+            def on_get(self, req, resp):
+                _set_response(resp, "{}.html".format(name))
+
+    else:
+
+        class _View(object):
+            def trigger(self, command):
+                pass
+
+            def on_get(self, req, resp):
+                user_input = req.get_param("user_input") or ""
+                catch_exception = req.get_param_as_bool("catch_exception")
+
+                if catch_exception:
+                    try:
+                        self.trigger(user_input)
+                    except Exception:
+                        pass
+                else:
+                    self.trigger(user_input)
+
+                _set_response(resp, "{}.html".format(name))
+
+    return _View
+
+
+def find_base_class(name):
+    """
+    Find a class LIKE name currently defined in this module.
+
+    :param name: str
+    :return: class matching "name"
+    """
+    current_module = sys.modules[__name__]
+
+    for obj_name, obj in inspect.getmembers(current_module):
+        if inspect.isclass(obj) and obj_name == name.title():
+            return obj
+
+
+def get_trigger_view(name, trigger):
+
+    baseclass = find_base_class(name)
+
+    class _View(baseclass):
+        def trigger(self, command):
+            module = sys.modules.get("vulnpy.trigger.{}".format(name))
+            trigger_func = get_trigger(module, trigger)
+
+            if trigger_func:
+                trigger_func(command)
+
+    return _View
+
+
+def generate_root_urls(app):
+    for name in TRIGGER_MAP:
+        view_name = get_root_name(name)
+        view_cls = gen_root_view(name)
+
+        # Add the view class to the current module to be able to retrieve later
+        current_module = sys.modules[__name__]
+        setattr(current_module, name.title(), view_cls)
+
+        app.add_route(view_name, view_cls())
+
+
+def generate_trigger_urls(app):
+    for name, triggers in TRIGGER_MAP.items():
+        for trigger in triggers:
+            view_name = get_trigger_name(name, trigger)
+
+            view_cls = get_trigger_view(name, trigger)
+
+            app.add_route(view_name, view_cls())
 
 
 def add_vulnerable_routes(app):
@@ -10,18 +103,10 @@ def add_vulnerable_routes(app):
     :param app: instance of falcon.API
     """
     app.req_options.strip_url_path_trailing_slash = True
-    app.add_route("/vulnpy", Home())
 
-    app.add_route("/vulnpy/cmdi", Cmdi())
-    app.add_route("/vulnpy/cmdi/os-system", OsSystem())
-    app.add_route("/vulnpy/cmdi/subprocess-popen", SubprocessPopen())
-
-    app.add_route("/vulnpy/deserialization", Deserialization())
-    app.add_route("/vulnpy/deserialization/pickle-load", PickleLoad())
-    app.add_route("/vulnpy/deserialization/pickle-loads", PickleLoads())
-
-    app.add_route("/vulnpy/deserialization/yaml-load", YamlLoad())
-    app.add_route("/vulnpy/deserialization/yaml-load-all", YamlLoadAll())
+    # Root urls must be generated before trigger urls.
+    generate_root_urls(app)
+    generate_trigger_urls(app)
 
 
 def _set_response(resp, path):
@@ -30,67 +115,3 @@ def _set_response(resp, path):
     """
     resp.body = get_template(path)
     resp.content_type = "text/html"
-
-
-class Home(object):
-    def on_get(self, req, resp):
-        _set_response(resp, "home.html")
-
-
-class Cmdi(object):
-    def trigger(self, command):
-        pass
-
-    def on_get(self, req, resp):
-        user_input = req.get_param("user_input") or ""
-        catch_exception = req.get_param_as_bool("catch_exception")
-
-        if catch_exception:
-            try:
-                self.trigger(user_input)
-            except Exception:
-                pass
-        else:
-            self.trigger(user_input)
-
-        _set_response(resp, "cmdi.html")
-
-
-class OsSystem(Cmdi):
-    def trigger(self, command):
-        cmdi.do_os_system(command)
-
-
-class SubprocessPopen(Cmdi):
-    def trigger(self, command):
-        cmdi.do_subprocess_popen(command)
-
-
-class Deserialization(object):
-    def trigger(self, command):
-        pass
-
-    def on_get(self, req, resp):
-        user_input = req.get_param("user_input") or ""
-        self.trigger(user_input)
-        _set_response(resp, "deserialization.html")
-
-
-class PickleLoad(Deserialization):
-    def trigger(self, command):
-        deserialization.do_pickle_load(command)
-
-
-class PickleLoads(Deserialization):
-    def trigger(self, command):
-        deserialization.do_pickle_loads(command)
-
-
-class YamlLoad(Deserialization):
-    def trigger(self, command):
-        deserialization.do_yaml_load(command)
-
-
-class YamlLoadAll(Deserialization):
-    def trigger(self, command):
-        deserialization.do_yaml_load_all(command)

--- a/src/vulnpy/flask/blueprint.py
+++ b/src/vulnpy/flask/blueprint.py
@@ -1,8 +1,7 @@
-import sys
 from flask import Blueprint, request
 
 from vulnpy.common import get_template
-from vulnpy.trigger import TRIGGER_MAP, get_trigger, cmdi, deserialization  # noqa: F401
+from vulnpy.trigger import TRIGGER_MAP, get_trigger
 
 vulnerable_blueprint = Blueprint(
     "vulnpy",
@@ -46,9 +45,7 @@ def generate_root_urls():
 def get_trigger_view(name, trigger):
     def _view():
         user_input = _get_user_input()
-
-        module = sys.modules.get("vulnpy.trigger.{}".format(name))
-        trigger_func = get_trigger(module, trigger)
+        trigger_func = get_trigger(name, trigger)
 
         if trigger_func:
             trigger_func(user_input)

--- a/src/vulnpy/pyramid/vulnerable_routes.py
+++ b/src/vulnpy/pyramid/vulnerable_routes.py
@@ -1,8 +1,7 @@
-import sys
 from pyramid.response import Response
 
 from vulnpy.common import get_template
-from vulnpy.trigger import TRIGGER_MAP, get_trigger, cmdi, deserialization  # noqa: F401
+from vulnpy.trigger import TRIGGER_MAP, get_trigger
 
 
 def _get_user_input(request):
@@ -41,9 +40,7 @@ def gen_root_view(name):
 def get_trigger_view(name, trigger):
     def _view(request):
         user_input = _get_user_input(request)
-
-        module = sys.modules.get("vulnpy.trigger.{}".format(name))
-        trigger_func = get_trigger(module, trigger)
+        trigger_func = get_trigger(name, trigger)
 
         if trigger_func:
             trigger_func(user_input)

--- a/src/vulnpy/pyramid/vulnerable_routes.py
+++ b/src/vulnpy/pyramid/vulnerable_routes.py
@@ -17,12 +17,6 @@ def get_root_pattern(name):
     return "/vulnpy/{}".format(name)
 
 
-def get_root_pattern(name):
-    if name == "home":
-        return "/vulnpy"
-    return "/vulnpy/{}".format(name)
-
-
 def get_trigger_pattern(name, trigger):
     return "/vulnpy/{}/{}".format(name, trigger)
 

--- a/src/vulnpy/trigger/__init__.py
+++ b/src/vulnpy/trigger/__init__.py
@@ -26,4 +26,5 @@ def get_trigger(module, trigger_name):
     try:
         return getattr(module, func_name)
     except AttributeError:
-        return
+        print("Cannot find function {} in module {}", func_name, module.__name__)
+        raise

--- a/src/vulnpy/trigger/__init__.py
+++ b/src/vulnpy/trigger/__init__.py
@@ -1,35 +1,3 @@
-from importlib import import_module
+from vulnpy.trigger.util import create_trigger_map, get_trigger  # noqa: F401
 
-TRIGGER_MAP = {
-    "home": [],
-    "cmdi": [
-        "os-system",
-        "subprocess-popen",
-    ],
-    "deserialization": [
-        "pickle-load",
-        "pickle-loads",
-        "yaml-load",
-        "yaml-load-all",
-    ],
-}
-
-
-def get_trigger(name, trigger_name):
-    """
-    Find a function LIKE trigger_name in the module.
-
-    :param name: str representing file name where trigger is located
-    :param trigger_name: str
-    :return: function
-    """
-    module_name = "vulnpy.trigger.{}".format(name)
-    module = import_module(module_name)
-
-    func_name = "do_{}".format(trigger_name.replace("-", "_"))
-
-    try:
-        return getattr(module, func_name)
-    except AttributeError:
-        print("Cannot find function {} in module {}", func_name, module.__name__)
-        raise
+TRIGGER_MAP = create_trigger_map()

--- a/src/vulnpy/trigger/__init__.py
+++ b/src/vulnpy/trigger/__init__.py
@@ -1,0 +1,13 @@
+TRIGGER_MAP = {
+    "home": [],
+    "cmdi": [
+        "os-system",
+        "subprocess-popen",
+    ],
+    "deserialization": [
+        "pickle-load",
+        "pickle-loads",
+        "yaml-load",
+        "yaml-load-all",
+    ],
+}

--- a/src/vulnpy/trigger/__init__.py
+++ b/src/vulnpy/trigger/__init__.py
@@ -1,3 +1,5 @@
+from importlib import import_module
+
 TRIGGER_MAP = {
     "home": [],
     "cmdi": [
@@ -13,14 +15,17 @@ TRIGGER_MAP = {
 }
 
 
-def get_trigger(module, trigger_name):
+def get_trigger(name, trigger_name):
     """
     Find a function LIKE trigger_name in the module.
 
-    :param module: Python module
+    :param name: str representing file name where trigger is located
     :param trigger_name: str
     :return: function
     """
+    module_name = "vulnpy.trigger.{}".format(name)
+    module = import_module(module_name)
+
     func_name = "do_{}".format(trigger_name.replace("-", "_"))
 
     try:

--- a/src/vulnpy/trigger/__init__.py
+++ b/src/vulnpy/trigger/__init__.py
@@ -11,3 +11,19 @@ TRIGGER_MAP = {
         "yaml-load-all",
     ],
 }
+
+
+def get_trigger(module, trigger_name):
+    """
+    Find a function LIKE trigger_name in the module.
+
+    :param module: Python module
+    :param trigger_name: str
+    :return: function
+    """
+    func_name = "do_{}".format(trigger_name.replace("-", "_"))
+
+    try:
+        return getattr(module, func_name)
+    except AttributeError:
+        return

--- a/src/vulnpy/trigger/util.py
+++ b/src/vulnpy/trigger/util.py
@@ -1,0 +1,62 @@
+import glob
+import inspect
+from importlib import import_module
+from os.path import dirname, basename, isfile, join
+
+
+def _get_trigger_files():
+    """
+    Find the file names under /trigger.
+
+    :return: list of str partial file names, ie ['cmdi', 'deserialization']
+    """
+    all_files = glob.glob(join(dirname(__file__), "*.py"))
+    trigger_files = [
+        basename(f)[:-3]
+        for f in all_files
+        if isfile(f) and not f.endswith("__init__.py")
+    ]
+
+    return trigger_files
+
+
+def _get_trigger_module(name):
+    module_name = "vulnpy.trigger.{}".format(name)
+    return import_module(module_name)
+
+
+def create_trigger_map():
+    map = {"home": []}
+
+    trigger_files = _get_trigger_files()
+
+    for vuln_name in trigger_files:
+        map.setdefault(vuln_name, [])
+
+        module = _get_trigger_module(vuln_name)
+
+        for obj_name, _ in inspect.getmembers(module):
+            if obj_name.startswith("do"):
+                trigger_name = obj_name.replace("do_", "").replace("_", "-")
+                map[vuln_name].append(trigger_name)
+
+    return map
+
+
+def get_trigger(name, trigger_name):
+    """
+    Find a function LIKE trigger_name in the module.
+
+    :param name: str representing file name where trigger is located
+    :param trigger_name: str
+    :return: function
+    """
+    module = _get_trigger_module(name)
+
+    func_name = "do_{}".format(trigger_name.replace("-", "_"))
+
+    try:
+        return getattr(module, func_name)
+    except AttributeError:
+        print("Cannot find function {} in module {}", func_name, module.__name__)
+        raise

--- a/tests/trigger/test_trigger.py
+++ b/tests/trigger/test_trigger.py
@@ -5,6 +5,6 @@ from vulnpy.trigger import get_trigger
 
 def test_get_trigger_does_not_exist():
     with pytest.raises(AttributeError) as exc:
-        get_trigger(pytest, "nope")
+        get_trigger("cmdi", "nope")
 
     assert "do_nope" in str(exc)

--- a/tests/trigger/test_trigger.py
+++ b/tests/trigger/test_trigger.py
@@ -1,0 +1,10 @@
+import pytest
+
+from vulnpy.trigger import get_trigger
+
+
+def test_get_trigger_does_not_exist():
+    with pytest.raises(AttributeError) as exc:
+        get_trigger(pytest, "nope")
+
+    assert "do_nope" in str(exc)


### PR DESCRIPTION
This PR seeks to make adding new triggers to vulnpy easier by automating each framework's view generation.

This is certainly not final and can use more work later on, but this is a good stopping point. I also did consider deduping some of the inter-framework code similarities, but I decided against it right now. A class could help, but I think that would add more complexity than it merits. Right now each framework does its own tiny different thing in its own file - let's not make it more complicated for now.