### PR TITLE
Pyt 992 consolidate testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,13 @@ function definition must be prefixed with "do_".**
 4. Add a new file under templates/fragments/vulnname.frag.html OR use the existing 
 one to add a new fragment for the trigger. This step may be automated in the future.
 
-5. Add a new <li> element to the menu bar in templates/fragments/base.html for this 
+5. Add a new `<li>` element to the menu bar in templates/fragments/base.html for this 
 vulnname.
  
-6. Add tests under trigger/ and for each of the frameworks to call the new trigger.
-
+6. Add tests under trigger/ and make sure to use `BaseTriggerTest`. Tests must be 
+added until - at a minimum - full test coverage is reached.
+    * As part of this step you may need to update `DATA` if this is a new vulnerability.
+    
 7. Run an app with `make flask` (or other framework) to test this new vulnerability / 
 trigger(s):
 

--- a/src/vulnpy/trigger/__init__.py
+++ b/src/vulnpy/trigger/__init__.py
@@ -1,3 +1,10 @@
 from vulnpy.trigger.util import create_trigger_map, get_trigger  # noqa: F401
 
 TRIGGER_MAP = create_trigger_map()
+
+DATA = {
+    "cmdi": "echo attack",
+    "deserialization": "csubprocess\ncheck_output\n(S'ls'\ntR.",  # TODO yaml data
+    "unsafe_code_exec": "1 + 2",
+    "xxe": "<root>attack</root>",
+}

--- a/src/vulnpy/trigger/__init__.py
+++ b/src/vulnpy/trigger/__init__.py
@@ -2,9 +2,13 @@ from vulnpy.trigger.util import create_trigger_map, get_trigger  # noqa: F401
 
 TRIGGER_MAP = create_trigger_map()
 
+
+# This test data assumes that all triggers for the vulnerability accept the same
+# user input. However, this isn't always true, as in the case of deserialization
+# pickle and yaml. However, for test purposes, this is fine.
 DATA = {
     "cmdi": "echo attack",
-    "deserialization": "csubprocess\ncheck_output\n(S'ls'\ntR.",  # TODO yaml data
+    "deserialization": "csubprocess\ncheck_output\n(S'ls'\ntR.",
     "unsafe_code_exec": "1 + 2",
     "xxe": "<root>attack</root>",
 }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 import pytest
 
-from vulnpy.trigger import TRIGGER_MAP, DATA
+from vulnpy.trigger import TRIGGER_MAP
 
 VULN_NAMES = [x for x in TRIGGER_MAP if x != "util"]
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,15 @@
+import pytest
+
+from vulnpy.trigger import TRIGGER_MAP, DATA
+
+VULN_NAMES = [x for x in TRIGGER_MAP if x != "util"]
+
+ARGLIST = []
+for vuln_name, trigger_names in TRIGGER_MAP.items():
+    if not trigger_names:
+        continue
+    for trigger in trigger_names:
+        ARGLIST.append((vuln_name, trigger))
+
+parametrize_root = pytest.mark.parametrize("view_name", VULN_NAMES)
+parametrize_triggers = pytest.mark.parametrize("view_name,trigger_name", ARGLIST)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,14 +2,36 @@ import pytest
 
 from vulnpy.trigger import TRIGGER_MAP
 
-VULN_NAMES = [x for x in TRIGGER_MAP if x != "util"]
 
-ARGLIST = []
-for vuln_name, trigger_names in TRIGGER_MAP.items():
-    if not trigger_names:
-        continue
-    for trigger in trigger_names:
-        ARGLIST.append((vuln_name, trigger))
+def _make_trigger_list():
+    arglist = []
+    for vuln_name, trigger_names in TRIGGER_MAP.items():
+        if not trigger_names:
+            continue
+        for trigger in trigger_names:
+            arglist.append((vuln_name, trigger))
 
-parametrize_root = pytest.mark.parametrize("view_name", VULN_NAMES)
-parametrize_triggers = pytest.mark.parametrize("view_name,trigger_name", ARGLIST)
+    return arglist
+
+
+def _make_view_paths():
+    view_paths = []
+
+    for vuln_name in TRIGGER_MAP:
+        if vuln_name == "util":
+            continue
+
+        if vuln_name == "home":
+            path = "/vulnpy"
+        else:
+            path = "/vulnpy/{}".format(vuln_name)
+
+        view_paths.append(path)
+
+    return view_paths
+
+
+parametrize_root = pytest.mark.parametrize("view_path", _make_view_paths())
+parametrize_triggers = pytest.mark.parametrize(
+    "view_name,trigger_name", _make_trigger_list()
+)

--- a/tests/django/test_vulnerable.py
+++ b/tests/django/test_vulnerable.py
@@ -2,16 +2,8 @@ import pytest
 from django.conf import settings
 from django.test import Client
 
-from vulnpy.trigger import TRIGGER_MAP, DATA
-
-vuln_names = [x for x in TRIGGER_MAP if x != "util"]
-
-arglist = []
-for vuln_name, trigger_names in TRIGGER_MAP.items():
-    if not trigger_names:
-        continue
-    for trigger in trigger_names:
-        arglist.append((vuln_name, trigger))
+from vulnpy.trigger import DATA
+from tests import parametrize_root, parametrize_triggers
 
 
 @pytest.fixture(scope="module")
@@ -22,7 +14,7 @@ def client():
     return Client()
 
 
-@pytest.mark.parametrize("view_name", vuln_names)
+@parametrize_root
 def test_root_views(client, view_name):
     if view_name == "home":
         response = client.get("/vulnpy")
@@ -31,7 +23,7 @@ def test_root_views(client, view_name):
     assert response.status_code == 200
 
 
-@pytest.mark.parametrize("view_name,trigger_name", arglist)
+@parametrize_triggers
 @pytest.mark.parametrize("request_method", ["get", "post"])
 def test_trigger(client, request_method, view_name, trigger_name):
     get_or_post = getattr(client, request_method)

--- a/tests/django/test_vulnerable.py
+++ b/tests/django/test_vulnerable.py
@@ -2,6 +2,17 @@ import pytest
 from django.conf import settings
 from django.test import Client
 
+from vulnpy.trigger import TRIGGER_MAP, DATA
+
+vuln_names = [x for x in TRIGGER_MAP if x != "util"]
+
+arglist = []
+for vuln_name, trigger_names in TRIGGER_MAP.items():
+    if not trigger_names:
+        continue
+    for trigger in trigger_names:
+        arglist.append((vuln_name, trigger))
+
 
 @pytest.fixture(scope="module")
 def client():
@@ -11,136 +22,21 @@ def client():
     return Client()
 
 
-def test_vulnpy_root(client):
-    response = client.get("/vulnpy")
+@pytest.mark.parametrize("view_name", vuln_names)
+def test_root_views(client, view_name):
+    if view_name == "home":
+        response = client.get("/vulnpy")
+    else:
+        response = client.get("/vulnpy/{}".format(view_name))
     assert response.status_code == 200
 
 
-def test_cmdi_basic(client):
-    response = client.get("/vulnpy/cmdi")
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_cmdi_os_system_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post("/vulnpy/cmdi/os-system", {"user_input": "echo attack"})
-    assert response.status_code == 200
-
-
-def test_cmdi_os_system_bad_command(client):
-    response = client.get("/vulnpy/cmdi/os-system", {"user_input": "foo"})
-    assert response.status_code == 200
-
-
-def test_cmdi_os_system_invalid_input(client):
-    response = client.get("/vulnpy/cmdi/os-system", {"ignored_param": "bad"})
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_cmdi_subprocess_popen_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
+@pytest.mark.parametrize("view_name,trigger_name", arglist)
+@pytest.mark.parametrize("request_method", ["get", "post"])
+def test_trigger(client, request_method, view_name, trigger_name):
+    get_or_post = getattr(client, request_method)
     response = get_or_post(
-        "/vulnpy/cmdi/subprocess-popen", {"user_input": "echo attack"}
-    )
-    assert response.status_code == 200
-
-
-def test_cmdi_subprocess_popen_bad_command(client):
-    response = client.get("/vulnpy/cmdi/subprocess-popen", {"user_input": "foo"})
-    assert response.status_code == 200
-
-
-def test_cmdi_subprocess_popen_invalid_input(client):
-    response = client.get("/vulnpy/cmdi/subprocess-popen", {"ignored_param": "bad"})
-    assert response.status_code == 200
-
-
-def test_deserialization_basic(client):
-    response = client.get("/vulnpy/deserialization")
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_deserialization_pickle_load_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/deserialization/pickle-load",
-        {"user_input": "csubprocess\ncheck_output\n(S'ls'\ntR."},
-    )
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_deserialization_pickle_loads_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/deserialization/pickle-loads",
-        {"user_input": "csubprocess\ncheck_output\n(S'ls'\ntR."},
-    )
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_deserialization_yaml_load_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/deserialization/yaml-load",
-        {
-            "user_input": '!!python/object/apply:subprocess.Popen [["echo", "Hello World"]]'
-        },
-    )
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_deserialization_yaml_load_all_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/deserialization/yaml-load-all",
-        {
-            "user_input": '!!python/object/apply:subprocess.Popen [["echo", "Hello World"]]'
-        },
-    )
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-@pytest.mark.parametrize("endpoint", ["eval", "exec", "compile"])
-def test_unsafe_code_exec_normal(client, method_name, endpoint):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/unsafe_code_exec/{}/".format(endpoint), {"user_input": "1 + 2"}
-    )
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_xxe_lxml_etree_fromstring_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/xxe/lxml-etree-fromstring",
-        {"user_input": "<root>attack</root>"},
-    )
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_xxe_xml_dom_pulldom_parsestring_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/xxe/xml-dom-pulldom-parsestring",
-        {"user_input": "<root>attack</root>"},
-    )
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_xxe_xml_sax_parsestring_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/xxe/xml-sax-parsestring",
-        {"user_input": "<root>attack</root>"},
+        "/vulnpy/{}/{}".format(view_name, trigger_name),
+        {"user_input": DATA.get(view_name)},
     )
     assert response.status_code == 200

--- a/tests/django/test_vulnerable.py
+++ b/tests/django/test_vulnerable.py
@@ -15,11 +15,8 @@ def client():
 
 
 @parametrize_root
-def test_root_views(client, view_name):
-    if view_name == "home":
-        response = client.get("/vulnpy")
-    else:
-        response = client.get("/vulnpy/{}".format(view_name))
+def test_root_views(client, view_path):
+    response = client.get(view_path)
     assert response.status_code == 200
 
 
@@ -29,6 +26,6 @@ def test_trigger(client, request_method, view_name, trigger_name):
     get_or_post = getattr(client, request_method)
     response = get_or_post(
         "/vulnpy/{}/{}".format(view_name, trigger_name),
-        {"user_input": DATA.get(view_name)},
+        {"user_input": DATA[view_name]},
     )
     assert response.status_code == 200

--- a/tests/falcon/test_vulnerable.py
+++ b/tests/falcon/test_vulnerable.py
@@ -20,11 +20,8 @@ def client():
 
 
 @parametrize_root
-def test_root_views(client, view_name):
-    if view_name == "home":
-        response = client.simulate_get("/vulnpy")
-    else:
-        response = client.simulate_get("/vulnpy/{}".format(view_name))
+def test_root_views(client, view_path):
+    response = client.simulate_get(view_path)
     assert response.status_code == 200
 
 
@@ -33,10 +30,10 @@ def test_root_views(client, view_name):
 def test_trigger(client, request_method, view_name, trigger_name):
     get_or_post = getattr(client, request_method)
 
-    data = DATA.get(view_name)
+    data = DATA[view_name]
 
-    if view_name == "unsafe_code_exec":
-        data = quote(data)
+    # to make unsafe_code_exec trigger work
+    data = quote(data)
 
     response = get_or_post(
         "/vulnpy/{}/{}".format(view_name, trigger_name),

--- a/tests/falcon/test_vulnerable.py
+++ b/tests/falcon/test_vulnerable.py
@@ -8,6 +8,9 @@ from falcon import testing
 import vulnpy
 import vulnpy.falcon
 
+from vulnpy.trigger import DATA
+from tests import parametrize_root, parametrize_triggers
+
 
 @pytest.fixture(scope="module")
 def client():
@@ -16,54 +19,28 @@ def client():
     return testing.TestClient(app)
 
 
-def test_home(client):
-    response = client.simulate_get("/vulnpy")
+@parametrize_root
+def test_root_views(client, view_name):
+    if view_name == "home":
+        response = client.simulate_get("/vulnpy")
+    else:
+        response = client.simulate_get("/vulnpy/{}".format(view_name))
     assert response.status_code == 200
 
 
-def test_cmdi_basic(client):
-    response = client.simulate_get("/vulnpy/cmdi")
-    assert response.status_code == 200
+@parametrize_triggers
+@pytest.mark.parametrize("request_method", ["simulate_get"])
+def test_trigger(client, request_method, view_name, trigger_name):
+    get_or_post = getattr(client, request_method)
 
+    data = DATA.get(view_name)
 
-def test_cmdi_os_system_normal(client):
-    response = client.simulate_get(
-        "/vulnpy/cmdi/os-system", params={"user_input": "echo attack"}
-    )
-    assert response.status_code == 200
+    if view_name == "unsafe_code_exec":
+        data = quote(data)
 
-
-def test_cmdi_os_system_bad_command(client):
-    response = client.simulate_get(
-        "/vulnpy/cmdi/os-system", params={"user_input": "foo"}
-    )
-    assert response.status_code == 200
-
-
-def test_cmdi_os_system_invalid_input(client):
-    response = client.simulate_get(
-        "/vulnpy/cmdi/os-system", params={"ignored_param": "bad"}
-    )
-    assert response.status_code == 200
-
-
-def test_cmdi_subprocess_popen_normal(client):
-    response = client.simulate_get(
-        "/vulnpy/cmdi/subprocess-popen", params={"user_input": "echo attack"}
-    )
-    assert response.status_code == 200
-
-
-def test_cmdi_subprocess_popen_bad_command(client):
-    response = client.simulate_get(
-        "/vulnpy/cmdi/subprocess-popen", params={"user_input": "foo"}
-    )
-    assert response.status_code == 200
-
-
-def test_cmdi_subprocess_popen_invalid_input(client):
-    response = client.simulate_get(
-        "/vulnpy/cmdi/subprocess-popen", params={"ignored_param": "bad"}
+    response = get_or_post(
+        "/vulnpy/{}/{}".format(view_name, trigger_name),
+        params={"user_input": data},
     )
     assert response.status_code == 200
 
@@ -79,76 +56,3 @@ def test_handle_exception(mocked_trigger, client):
     assert mocked_trigger.called
     assert response.status_code == 200
 
-
-def test_deserialization_basic(client):
-    response = client.simulate_get("/vulnpy/deserialization")
-    assert response.status_code == 200
-
-
-def test_deserialization_pickle_load_normal(client):
-    response = client.simulate_get(
-        "/vulnpy/deserialization/pickle-load",
-        params={"user_input": "csubprocess\ncheck_output\n(S'ls'\ntR."},
-    )
-    assert response.status_code == 200
-
-
-def test_deserialization_pickle_loads_normal(client):
-    response = client.simulate_get(
-        "/vulnpy/deserialization/pickle-loads",
-        params={"user_input": "csubprocess\ncheck_output\n(S'ls'\ntR."},
-    )
-    assert response.status_code == 200
-
-
-def test_deserialization_yaml_load_normal(client):
-    response = client.simulate_get(
-        "/vulnpy/deserialization/yaml-load",
-        params={
-            "user_input": '!!python/object/apply:subprocess.Popen [["echo", "Hello World"]]'
-        },
-    )
-    assert response.status_code == 200
-
-
-def test_deserialization_yaml_load_all_normal(client):
-    response = client.simulate_get(
-        "/vulnpy/deserialization/yaml-load-all",
-        params={
-            "user_input": '!!python/object/apply:subprocess.Popen [["echo", "Hello World"]]'
-        },
-    )
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("endpoint", ["eval", "exec", "compile"])
-def test_unsafe_code_exec_normal(client, endpoint):
-    response = client.simulate_get(
-        "/vulnpy/unsafe_code_exec/{}".format(endpoint),
-        params={"user_input": quote("1 + 2")},
-    )
-    assert response.status_code == 200
-
-
-def test_xxe_lxml_etree_fromstring_normal(client):
-    response = client.simulate_get(
-        "/vulnpy/xxe/lxml-etree-fromstring",
-        params={"user_input": "<root>attack</root>"},
-    )
-    assert response.status_code == 200
-
-
-def test_xxe_xml_dom_pulldom_parsestring_normal(client):
-    response = client.simulate_get(
-        "/vulnpy/xxe/xml-dom-pulldom-parsestring",
-        params={"user_input": "<root>attack</root>"},
-    )
-    assert response.status_code == 200
-
-
-def test_xxe_xml_sax_parsestring_normal(client):
-    response = client.simulate_get(
-        "/vulnpy/xxe/xml-sax-parsestring",
-        params={"user_input": "<root>attack</root>"},
-    )
-    assert response.status_code == 200

--- a/tests/falcon/test_vulnerable.py
+++ b/tests/falcon/test_vulnerable.py
@@ -55,4 +55,3 @@ def test_handle_exception(mocked_trigger, client):
     )
     assert mocked_trigger.called
     assert response.status_code == 200
-

--- a/tests/flask/test_blueprint.py
+++ b/tests/flask/test_blueprint.py
@@ -3,6 +3,9 @@ from flask import Flask
 
 from vulnpy.flask.blueprint import vulnerable_blueprint
 
+from vulnpy.trigger import DATA
+from tests import parametrize_root, parametrize_triggers
+
 
 @pytest.fixture(scope="module")
 def client():
@@ -12,167 +15,27 @@ def client():
         yield client
 
 
-def test_home(client):
-    response = client.get("/vulnpy/")
+@parametrize_root
+def test_root_views(client, view_name):
+    if view_name == "home":
+        response = client.get("/vulnpy")
+    else:
+        response = client.get("/vulnpy/{}".format(view_name))
     assert response.status_code == 200
 
 
-def test_cmdi_basic(client):
-    response = client.get("/vulnpy/cmdi")
-    assert response.status_code == 200
+@parametrize_triggers
+@pytest.mark.parametrize("request_method", ["get", "post"])
+def test_trigger(client, request_method, view_name, trigger_name):
+    get_or_post = getattr(client, request_method)
 
+    data = DATA.get(view_name)
 
-def test_deserialization_basic(client):
-    response = client.get("/vulnpy/deserialization")
-    assert response.status_code == 200
+    if view_name == "unsafe_code_exec":
+        data = "'{}'".format(data)
 
-
-def test_cmdi_os_system_get(client):
-    response = client.get("/vulnpy/cmdi/os-system/?user_input=echo%20attack")
-    assert response.status_code == 200
-
-
-def test_cmdi_os_system_post(client):
-    response = client.post(
-        "/vulnpy/cmdi/os-system/", data={"user_input": "echo attack"}
-    )
-    assert response.status_code == 200
-
-
-def test_cmdi_os_system_bad_command(client):
-    response = client.get("/vulnpy/cmdi/os-system/?user_input=foo")
-    assert response.status_code == 200
-
-
-def test_cmdi_os_system_invalid_input(client):
-    response = client.get("/vulnpy/cmdi/os-system/?ignored_param=bad")
-    assert response.status_code == 200
-
-
-def test_cmdi_subprocess_popen_get(client):
-    response = client.get("/vulnpy/cmdi/subprocess-popen/?user_input=echo%20attack")
-    assert response.status_code == 200
-
-
-def test_cmdi_subprocess_popen_post(client):
-    response = client.post(
-        "/vulnpy/cmdi/subprocess-popen/", data={"user_input": "echo attack"}
-    )
-    assert response.status_code == 200
-
-
-def test_cmdi_subprocess_popen_bad_command(client):
-    response = client.get("/vulnpy/cmdi/subprocess-popen/?user_input=foo")
-    assert response.status_code == 200
-
-
-def test_cmdi_subprocess_popen_invalid_input(client):
-    response = client.get("/vulnpy/cmdi/os-system/?ignored_param=bad")
-    assert response.status_code == 200
-
-
-def test_deserialization_pickle_load_get(client):
-    response = client.get(
-        "/vulnpy/deserialization/pickle-load/?user_input={}".format(
-            "csubprocess\ncheck_output\n(S'ls'\ntR."
-        )
-    )
-    assert response.status_code == 200
-
-
-def test_deserialization_pickle_load_post(client):
-    response = client.post(
-        "/vulnpy/deserialization/pickle-load/",
-        data={"user_input": "csubprocess\ncheck_output\n(" "S'ls'\ntR."},
-    )
-    assert response.status_code == 200
-
-
-def test_deserialization_pickle_loads_get(client):
-    response = client.get(
-        "/vulnpy/deserialization/pickle-loads/?user_input={}".format(
-            "csubprocess\ncheck_output\n(S'ls'\ntR."
-        )
-    )
-    assert response.status_code == 200
-
-
-def test_deserialization_pickle_loads_post(client):
-    response = client.post(
-        "/vulnpy/deserialization/pickle-loads/",
-        data={"user_input": "csubprocess\ncheck_output\n(S'ls'\ntR."},
-    )
-    assert response.status_code == 200
-
-
-def test_deserialization_yaml_load_get(client):
-    response = client.get(
-        "/vulnpy/deserialization/yaml-load/?user_input={}".format(
-            '!!python/object/apply:subprocess.Popen [["echo", "Hello World"]]'
-        )
-    )
-    assert response.status_code == 200
-
-
-def test_deserialization_yaml_load_post(client):
-    response = client.post(
-        "/vulnpy/deserialization/yaml-load/",
-        data={
-            "user_input": '!!python/object/apply:subprocess.Popen [["echo", "Hello World"]]'
-        },
-    )
-    assert response.status_code == 200
-
-
-def test_deserialization_yaml_load_all_get(client):
-    response = client.get(
-        "/vulnpy/deserialization/yaml-load-all/?user_input={}".format(
-            '!!python/object/apply:subprocess.Popen [["echo", "Hello World"]]'
-        )
-    )
-    assert response.status_code == 200
-
-
-def test_deserialization_yaml_load_all_post(client):
-    response = client.post(
-        "/vulnpy/deserialization/yaml-load-all/",
-        data={
-            "user_input": '!!python/object/apply:subprocess.Popen [["echo", "Hello World"]]'
-        },
-    )
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-@pytest.mark.parametrize("endpoint", ["eval", "exec", "compile"])
-def test_unsafe_code_exec(client, method_name, endpoint):
-    get_or_post = getattr(client, method_name)
     response = get_or_post(
-        '/vulnpy/unsafe_code_exec/{}/?user_input="1 + 2"'.format(endpoint),
-        data={"user_input": "1 + 2"},
-    )
-    assert response.status_code == 200
-
-
-def test_xxe_lxml_etree_fromstring_normal(client):
-    response = client.post(
-        "/vulnpy/xxe/lxml-etree-fromstring/",
-        data={"user_input": "<root>attack</root>"},
-    )
-    assert response.status_code == 200
-
-
-def test_xxe_xml_dom_pulldom_parsestring_normal(client):
-    response = client.post(
-        "/vulnpy/xxe/xml-dom-pulldom-parsestring/",
-        data={"user_input": "<root>attack</root>"},
-    )
-    assert response.status_code == 200
-
-
-def test_xxe_xml_sax_parsestring_normal(client):
-    response = client.post(
-        "/vulnpy/xxe/xml-sax-parsestring/",
-        data={"user_input": "<root>attack</root>"},
+        "/vulnpy/{}/{}/?user_input={}".format(view_name, trigger_name, data),
+        data={"user_input": data}
     )
     assert response.status_code == 200

--- a/tests/flask/test_blueprint.py
+++ b/tests/flask/test_blueprint.py
@@ -36,6 +36,6 @@ def test_trigger(client, request_method, view_name, trigger_name):
 
     response = get_or_post(
         "/vulnpy/{}/{}/?user_input={}".format(view_name, trigger_name, data),
-        data={"user_input": data}
+        data={"user_input": data},
     )
     assert response.status_code == 200

--- a/tests/flask/test_blueprint.py
+++ b/tests/flask/test_blueprint.py
@@ -16,11 +16,8 @@ def client():
 
 
 @parametrize_root
-def test_root_views(client, view_name):
-    if view_name == "home":
-        response = client.get("/vulnpy")
-    else:
-        response = client.get("/vulnpy/{}".format(view_name))
+def test_root_views(client, view_path):
+    response = client.get(view_path)
     assert response.status_code == 200
 
 
@@ -29,7 +26,7 @@ def test_root_views(client, view_name):
 def test_trigger(client, request_method, view_name, trigger_name):
     get_or_post = getattr(client, request_method)
 
-    data = DATA.get(view_name)
+    data = DATA[view_name]
 
     if view_name == "unsafe_code_exec":
         data = "'{}'".format(data)

--- a/tests/pyramid/test_vulnerable_routes.py
+++ b/tests/pyramid/test_vulnerable_routes.py
@@ -2,6 +2,9 @@ import pytest
 from pyramid.config import Configurator
 from webtest import TestApp
 
+from vulnpy.trigger import DATA
+from tests import parametrize_root, parametrize_triggers
+
 
 @pytest.fixture(scope="module")
 def client():
@@ -11,132 +14,21 @@ def client():
     return TestApp(app)
 
 
-def test_home(client):
-    response = client.get("/vulnpy/")
+@parametrize_root
+def test_root_views(client, view_name):
+    if view_name == "home":
+        response = client.get("/vulnpy")
+    else:
+        response = client.get("/vulnpy/{}".format(view_name))
     assert response.status_int == 200
 
 
-def test_cmdi_basic(client):
-    response = client.get("/vulnpy/cmdi")
-    assert response.status_int == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_cmdi_os_system_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post("/vulnpy/cmdi/os-system", {"user_input": "echo attack"})
-    assert response.status_int == 200
-
-
-def test_cmdi_os_system_bad_command(client):
-    response = client.get("/vulnpy/cmdi/os-system", {"user_input": "foo"})
-    assert response.status_int == 200
-
-
-def test_cmdi_os_system_invalid_input(client):
-    response = client.get("/vulnpy/cmdi/os-system", {"ignored_param": "bad"})
-    assert response.status_int == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_cmdi_subprocess_popen_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
+@parametrize_triggers
+@pytest.mark.parametrize("request_method", ["get", "post"])
+def test_trigger(client, request_method, view_name, trigger_name):
+    get_or_post = getattr(client, request_method)
     response = get_or_post(
-        "/vulnpy/cmdi/subprocess-popen", {"user_input": "echo attack"}
-    )
-    assert response.status_int == 200
-
-
-def test_cmdi_subprocess_popen_bad_command(client):
-    response = client.get("/vulnpy/cmdi/subprocess-popen", {"user_input": "foo"})
-    assert response.status_int == 200
-
-
-def test_cmdi_subprocess_popen_invalid_input(client):
-    response = client.get("/vulnpy/cmdi/subprocess-popen", {"ignored_param": "bad"})
-    assert response.status_int == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_deserialization_pickle_load_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/deserialization/pickle-load",
-        {"user_input": "csubprocess\ncheck_output\n(S'ls'\ntR."},
-    )
-    assert response.status_int == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_deserialization_pickle_loads_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/deserialization/pickle-loads",
-        {"user_input": "csubprocess\ncheck_output\n(S'ls'\ntR."},
-    )
-    assert response.status_int == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_deserialization_yaml_load_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/deserialization/yaml-load",
-        {
-            "user_input": '!!python/object/apply:subprocess.Popen [["echo", "Hello World"]]'
-        },
-    )
-    assert response.status_int == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_deserialization_yaml_load_all_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/deserialization/yaml-load-all",
-        {
-            "user_input": '!!python/object/apply:subprocess.Popen [["echo", "Hello World"]]'
-        },
-    )
-    assert response.status_int == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-@pytest.mark.parametrize("endpoint", ["eval", "exec", "compile"])
-def test_unsafe_code_exec(client, method_name, endpoint):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/unsafe_code_exec/{}".format(endpoint),
-        {"user_input": "1 + 2"},
+        "/vulnpy/{}/{}".format(view_name, trigger_name),
+        {"user_input": DATA.get(view_name)},
     )
     assert response.status_code == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_xxe_lxml_etree_fromstring_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/xxe/lxml-etree-fromstring",
-        {"user_input": "<root>attack</root>"},
-    )
-    assert response.status_int == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_xxe_xml_dom_pulldom_parsestring_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/xxe/xml-dom-pulldom-parsestring",
-        {"user_input": "<root>attack</root>"},
-    )
-    assert response.status_int == 200
-
-
-@pytest.mark.parametrize("method_name", ["get", "post"])
-def test_xxe_xml_sax_parsestring_normal(client, method_name):
-    get_or_post = getattr(client, method_name)
-    response = get_or_post(
-        "/vulnpy/xxe/xml-sax-parsestring",
-        {"user_input": "<root>attack</root>"},
-    )
-    assert response.status_int == 200

--- a/tests/pyramid/test_vulnerable_routes.py
+++ b/tests/pyramid/test_vulnerable_routes.py
@@ -15,11 +15,8 @@ def client():
 
 
 @parametrize_root
-def test_root_views(client, view_name):
-    if view_name == "home":
-        response = client.get("/vulnpy")
-    else:
-        response = client.get("/vulnpy/{}".format(view_name))
+def test_root_views(client, view_path):
+    response = client.get(view_path)
     assert response.status_int == 200
 
 
@@ -29,6 +26,6 @@ def test_trigger(client, request_method, view_name, trigger_name):
     get_or_post = getattr(client, request_method)
     response = get_or_post(
         "/vulnpy/{}/{}".format(view_name, trigger_name),
-        {"user_input": DATA.get(view_name)},
+        {"user_input": DATA[view_name]},
     )
     assert response.status_code == 200

--- a/tests/trigger/base_test.py
+++ b/tests/trigger/base_test.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+class BaseTriggerTest(object):
+    @property
+    def trigger_func(self):
+        raise NotImplementedError(
+            "This method should be implemented by each concrete subclass"
+        )
+
+    @property
+    def good_input(self):
+        raise NotImplementedError(
+            "This method should be implemented by each concrete subclass"
+        )
+
+    @property
+    def exception_input(self):
+        raise NotImplementedError(
+            "This method should be implemented by each concrete subclass"
+        )
+
+    @property
+    def exception_raised(self):
+        return TypeError
+
+    def test_good_input(self):
+        assert self.trigger_func(self.good_input[0]) == self.good_input[1]
+
+    def test_exception(self):
+        with pytest.raises(self.exception_raised):
+            self.trigger_func(self.exception_input)

--- a/tests/trigger/test_cmdi.py
+++ b/tests/trigger/test_cmdi.py
@@ -1,30 +1,30 @@
-import pytest
-
 from vulnpy.trigger import cmdi
+from tests.trigger.base_test import BaseTriggerTest
 
 
-def test_do_os_system():
-    assert cmdi.do_os_system("echo hacked") == 0
+class TestOsSystem(BaseTriggerTest):
+    @property
+    def trigger_func(self):
+        return cmdi.do_os_system
+
+    @property
+    def good_input(self):
+        return "echo hacked", 0
+
+    @property
+    def exception_input(self):
+        return None
 
 
-def test_do_os_system_bad_command():
-    assert cmdi.do_os_system("barrrrrr bad command") != 0
+class TestSubprocessPopen(BaseTriggerTest):
+    @property
+    def trigger_func(self):
+        return cmdi.do_subprocess_popen
 
+    @property
+    def good_input(self):
+        return "echo hacked", b"hacked\n"
 
-def test_do_os_system_exception():
-    with pytest.raises(TypeError):
-        cmdi.do_os_system(None)
-
-
-def test_do_subprocess_popen():
-    assert cmdi.do_subprocess_popen("echo hacked") == b"hacked\n"
-
-
-def test_do_subprocess_popen_bad_command():
-    """This makes some assumptions about the host system, but it seems to be generic enough"""
-    assert b"not found" in cmdi.do_subprocess_popen("foooooooo this is not a command")
-
-
-def test_do_subprocess_popen_exception():
-    with pytest.raises(TypeError):
-        cmdi.do_subprocess_popen(None)
+    @property
+    def exception_input(self):
+        return None

--- a/tests/trigger/test_deserialization.py
+++ b/tests/trigger/test_deserialization.py
@@ -1,0 +1,61 @@
+import pickle
+from six import PY2
+
+from vulnpy.trigger import deserialization
+from tests.trigger.base_test import BaseTriggerTest
+
+
+class BasePickleTest(object):
+    @property
+    def good_input(self):
+        return "cos\nsystem\n(S'echo hacked'\ntR.", 0
+
+    @property
+    def exception_input(self):
+        return "bad"
+
+    @property
+    def exception_raised(self):
+        if PY2:
+            return IndexError
+        return pickle.UnpicklingError
+
+
+class TestPickleLoad(BasePickleTest, BaseTriggerTest):
+    @property
+    def trigger_func(self):
+        return deserialization.do_pickle_load
+
+
+class TestPickleLoads(BasePickleTest, BaseTriggerTest):
+    @property
+    def trigger_func(self):
+        return deserialization.do_pickle_loads
+
+
+class BaseYamlTest(object):
+    @property
+    def good_input(self):
+        return '!!python/object/apply:subprocess.Popen [["echo", "Hello World"]]', None
+
+    @property
+    def exception_input(self):
+        return " Foo: !Ref bar"
+
+    def test_exception(self):
+        pass
+
+    def test_exception_caught(self):
+        self.trigger_func(self.exception_input)
+
+
+class TestYamlLoad(BaseYamlTest, BaseTriggerTest):
+    @property
+    def trigger_func(self):
+        return deserialization.do_yaml_load
+
+
+class TestYamlLoadAll(BaseYamlTest, BaseTriggerTest):
+    @property
+    def trigger_func(self):
+        return deserialization.do_yaml_load_all

--- a/tests/trigger/test_unsafe_code_exec.py
+++ b/tests/trigger/test_unsafe_code_exec.py
@@ -1,30 +1,59 @@
 import mock
-import pytest
 
 from vulnpy.trigger import unsafe_code_exec
+from tests.trigger.base_test import BaseTriggerTest
 
 
-@mock.patch("sys.stdout.write")
-def test_do_exec(mock_write):
-    unsafe_code_exec.do_exec('print("foo")')
-    assert mock_write.called
-    assert mock_write.call_args_list[0][0][0] == "foo"
+class TestExec(BaseTriggerTest):
+    @property
+    def trigger_func(self):
+        return unsafe_code_exec.do_exec
+
+    @property
+    def good_input(self):
+        return 'print("foo")', None
+
+    @property
+    def exception_input(self):
+        return None
+
+    @mock.patch("sys.stdout.write")
+    def test_good_input(self, mock_write):
+        self.trigger_func(self.good_input[0])
+        assert mock_write.called
+        assert mock_write.call_args_list[0][0][0] == "foo"
 
 
-def test_do_eval():
-    assert unsafe_code_exec.do_eval("37 + 5") == 42
+class TestEval(BaseTriggerTest):
+    @property
+    def trigger_func(self):
+        return unsafe_code_exec.do_eval
+
+    @property
+    def good_input(self):
+        return "1 + 1", 2
+
+    @property
+    def exception_input(self):
+        return '42 + "foo"'
 
 
-def test_do_eval_exeception():
-    with pytest.raises(TypeError):
-        unsafe_code_exec.do_eval('42 + "foo"')
+class TestCompile(BaseTriggerTest):
+    @property
+    def trigger_func(self):
+        return unsafe_code_exec.do_compile
 
+    @property
+    def good_input(self):
+        return 'print("foo")', None
 
-@mock.patch("sys.stdout.write")
-def test_do_compile(mock_write):
-    code = unsafe_code_exec.do_compile('print("foo")')
+    @property
+    def exception_input(self):
+        return None
 
-    exec(code)
-
-    assert mock_write.called
-    assert mock_write.call_args_list[0][0][0] == "foo"
+    @mock.patch("sys.stdout.write")
+    def test_good_input(self, mock_write):
+        code = self.trigger_func(self.good_input[0])
+        exec(code)
+        assert mock_write.called
+        assert mock_write.call_args_list[0][0][0] == "foo"


### PR DESCRIPTION
Consolidate unit tests to not require adding new framework tests when new triggers are added.

* We could dedupe some of the framework tests even more (django and flask share some methods) but it seemed overkill at this time

* we can't really automate tests under trigger/ as these are very custom. These tests themselves are a tiny bit overkill (we don't need to test the actual call to the trigger), but it's worth keeping high coverage. So for these tests the goal was to create an interface to make it very clear how to add new trigger tests (by inheriting BaseTriggerTest) and guide the developer.

* I removed some testing I don't think we need - framework tests checked for bad inputs given and so did trigger tests.