### PR TITLE
Add raw reflected xss support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ vulnname.
 6. Add tests under trigger/ and make sure to use `BaseTriggerTest`. Tests must be 
 added until - at a minimum - full test coverage is reached.
     * As part of this step you may need to update `DATA` if this is a new vulnerability.
-    
+
 7. Run an app with `make flask` (or other framework) to test this new vulnerability / 
 trigger(s):
 

--- a/src/vulnpy/django/vulnerable.py
+++ b/src/vulnpy/django/vulnerable.py
@@ -30,7 +30,12 @@ def get_trigger_view(name, trigger):
         if trigger_func:
             trigger_func(user_input)
 
-        return HttpResponse(get_template("{}.html".format(name)))
+        template = get_template("{}.html".format(name))
+
+        if name == "xss" and trigger == "raw":
+            template += "<p>XSS: " + user_input + "</p>"
+
+        return HttpResponse(template)
 
     return _view
 

--- a/src/vulnpy/falcon/vulnerable.py
+++ b/src/vulnpy/falcon/vulnerable.py
@@ -39,7 +39,10 @@ def gen_root_view(name):  # noqa: C901
                 else:
                     self.trigger(user_input)
 
-                _set_response(resp, "{}.html".format(name))
+                if name == "xss":
+                    _set_xss_response(resp, "{}.html".format(name), user_input)
+                else:
+                    _set_response(resp, "{}.html".format(name))
 
     return _View
 
@@ -113,4 +116,12 @@ def _set_response(resp, path):
     Set the response body and Content-Type
     """
     resp.body = get_template(path)
+    resp.content_type = "text/html"
+
+
+def _set_xss_response(resp, path, user_input):
+    template = get_template(path)
+    template += "<p>XSS: " + user_input + "</p>"
+
+    resp.body = template
     resp.content_type = "text/html"

--- a/src/vulnpy/flask/blueprint.py
+++ b/src/vulnpy/flask/blueprint.py
@@ -49,7 +49,13 @@ def get_trigger_view(name, trigger):
 
         if trigger_func:
             trigger_func(user_input)
-        return get_template("{}.html".format(name))
+
+        template = get_template("{}.html".format(name))
+
+        if name == "xss" and trigger == "raw":
+            template += "<p>XSS: " + user_input + "</p>"
+
+        return template
 
     view_name = get_trigger_name(name, trigger)
 

--- a/src/vulnpy/pyramid/vulnerable_routes.py
+++ b/src/vulnpy/pyramid/vulnerable_routes.py
@@ -44,7 +44,13 @@ def get_trigger_view(name, trigger):
 
         if trigger_func:
             trigger_func(user_input)
-        return Response(get_template("{}.html".format(name)))
+
+        template = get_template("{}.html".format(name))
+
+        if name == "xss" and trigger == "raw":
+            template += "<p>XSS: " + user_input + "</p>"
+
+        return Response(template)
 
     return _view
 

--- a/src/vulnpy/templates/cmdi.html
+++ b/src/vulnpy/templates/cmdi.html
@@ -20,6 +20,7 @@
               <li><a href="/vulnpy/cmdi/">CMD Injection</a></li>
               <li><a href="/vulnpy/deserialization/">Untrusted Deserialization</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
+              <li><a href="/vulnpy/xss/">XSS</a></li>
               <li><a href="/vulnpy/xxe/">XXE</a></li>
             </ul>
           </div>

--- a/src/vulnpy/templates/deserialization.html
+++ b/src/vulnpy/templates/deserialization.html
@@ -20,6 +20,7 @@
               <li><a href="/vulnpy/cmdi/">CMD Injection</a></li>
               <li><a href="/vulnpy/deserialization/">Untrusted Deserialization</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
+              <li><a href="/vulnpy/xss/">XSS</a></li>
               <li><a href="/vulnpy/xxe/">XXE</a></li>
             </ul>
           </div>

--- a/src/vulnpy/templates/fragments/base.html
+++ b/src/vulnpy/templates/fragments/base.html
@@ -19,6 +19,7 @@
               <li><a href="/vulnpy/cmdi/">CMD Injection</a></li>
               <li><a href="/vulnpy/deserialization/">Untrusted Deserialization</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
+              <li><a href="/vulnpy/xss/">XSS</a></li>
               <li><a href="/vulnpy/xxe/">XXE</a></li>
             </ul>
           </div>

--- a/src/vulnpy/templates/fragments/xss.frag.html
+++ b/src/vulnpy/templates/fragments/xss.frag.html
@@ -1,0 +1,15 @@
+<h1>XSS RAw</h1>
+
+<form action="/vulnpy/xss/raw/" method="get">
+  <div class="field has-addons">
+    <div class="control">
+      <input class="input" type="text" name="user_input" placeholder="attack">
+    </div>
+    <div class="control">
+      <button class="button is-info" action="submit">
+        Execute
+      </button>
+    </div>
+  </div>
+</form>
+<br>

--- a/src/vulnpy/templates/home.html
+++ b/src/vulnpy/templates/home.html
@@ -20,6 +20,7 @@
               <li><a href="/vulnpy/cmdi/">CMD Injection</a></li>
               <li><a href="/vulnpy/deserialization/">Untrusted Deserialization</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
+              <li><a href="/vulnpy/xss/">XSS</a></li>
               <li><a href="/vulnpy/xxe/">XXE</a></li>
             </ul>
           </div>

--- a/src/vulnpy/templates/unsafe_code_exec.html
+++ b/src/vulnpy/templates/unsafe_code_exec.html
@@ -20,6 +20,8 @@
               <li><a href="/vulnpy/cmdi/">CMD Injection</a></li>
               <li><a href="/vulnpy/deserialization/">Untrusted Deserialization</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
+              <li><a href="/vulnpy/xss/">XSS</a></li>
+              <li><a href="/vulnpy/xxe/">XXE</a></li>
             </ul>
           </div>
         </div>

--- a/src/vulnpy/templates/xss.html
+++ b/src/vulnpy/templates/xss.html
@@ -29,12 +29,12 @@
       <br>
       <div class="column container">
         <!-- ###vulnpy-injection-site### - do not modify this line; it's in a regex -->
-<h1>XXE: lxml.etree.fromstring</h1>
+<h1>XSS RAw</h1>
 
-<form action="/vulnpy/xxe/lxml-etree-fromstring/" method="get">
+<form action="/vulnpy/xss/raw/" method="get">
   <div class="field has-addons">
     <div class="control">
-      <input class="input" type="text" name="user_input" placeholder="<root>attack</root>">
+      <input class="input" type="text" name="user_input" placeholder="attack">
     </div>
     <div class="control">
       <button class="button is-info" action="submit">
@@ -43,40 +43,7 @@
     </div>
   </div>
 </form>
-<br>
-
-<h1>XXE: xml.dom.pulldom.parseString</h1>
-
-<form action="/vulnpy/xxe/xml-dom-pulldom-parsestring/" method="get">
-  <div class="field has-addons">
-    <div class="control">
-      <input class="input" type="text" name="user_input" placeholder="<root>attack</root>">
-    </div>
-    <div class="control">
-      <button class="button is-info" action="submit">
-        Execute
-      </button>
-    </div>
-  </div>
-</form>
-<br>
-
-<h1>XXE: xml.sax.parseString</h1>
-
-<form action="/vulnpy/xxe/xml-sax-parsestring/" method="get">
-  <div class="field has-addons">
-    <div class="control">
-      <input class="input" type="text" name="user_input" placeholder="<root>attack</root>">
-    </div>
-    <div class="control">
-      <button class="button is-info" action="submit">
-        Execute
-      </button>
-    </div>
-  </div>
-</form>
-<br>
-        <!-- post-injection site -->
+<br>        <!-- post-injection site -->
       </div>
     </div>
   </body>

--- a/src/vulnpy/trigger/__init__.py
+++ b/src/vulnpy/trigger/__init__.py
@@ -10,5 +10,6 @@ DATA = {
     "cmdi": "echo attack",
     "deserialization": "csubprocess\ncheck_output\n(S'ls'\ntR.",
     "unsafe_code_exec": "1 + 2",
+    "xss": "",
     "xxe": "<root>attack</root>",
 }

--- a/src/vulnpy/trigger/__init__.py
+++ b/src/vulnpy/trigger/__init__.py
@@ -10,6 +10,6 @@ DATA = {
     "cmdi": "echo attack",
     "deserialization": "csubprocess\ncheck_output\n(S'ls'\ntR.",
     "unsafe_code_exec": "1 + 2",
-    "xss": "",
+    "xss": "attack",
     "xxe": "<root>attack</root>",
 }

--- a/src/vulnpy/trigger/xss.py
+++ b/src/vulnpy/trigger/xss.py
@@ -1,4 +1,5 @@
 """XSS Does not have trigger functions"""
 
+
 def do_raw(user_input):
     return ""

--- a/src/vulnpy/trigger/xss.py
+++ b/src/vulnpy/trigger/xss.py
@@ -1,0 +1,4 @@
+"""XSS Does not have trigger functions"""
+
+def do_raw(user_input):
+    return ""

--- a/tests/django/test_vulnerable.py
+++ b/tests/django/test_vulnerable.py
@@ -29,3 +29,5 @@ def test_trigger(client, request_method, view_name, trigger_name):
         {"user_input": DATA[view_name]},
     )
     assert response.status_code == 200
+    if view_name == "xss":
+        assert "<p>XSS: {}</p>".format(DATA.get(view_name)) in str(response.content)

--- a/tests/falcon/test_vulnerable.py
+++ b/tests/falcon/test_vulnerable.py
@@ -41,6 +41,9 @@ def test_trigger(client, request_method, view_name, trigger_name):
     )
     assert response.status_code == 200
 
+    if view_name == "xss":
+        assert "<p>XSS: {}</p>".format(DATA.get(view_name)) in str(response.content)
+
 
 @mock.patch(
     "vulnpy.trigger.cmdi.do_os_system", side_effect=Exception("something bad happened")

--- a/tests/flask/test_blueprint.py
+++ b/tests/flask/test_blueprint.py
@@ -36,3 +36,6 @@ def test_trigger(client, request_method, view_name, trigger_name):
         data={"user_input": data},
     )
     assert response.status_code == 200
+
+    if view_name == "xss":
+        assert "<p>XSS: {}</p>".format(data) in str(response.get_data())

--- a/tests/pyramid/test_vulnerable_routes.py
+++ b/tests/pyramid/test_vulnerable_routes.py
@@ -29,3 +29,6 @@ def test_trigger(client, request_method, view_name, trigger_name):
         {"user_input": DATA[view_name]},
     )
     assert response.status_code == 200
+
+    if view_name == "xss":
+        assert "<p>XSS: {}</p>".format(DATA.get(view_name)) in str(response.text)

--- a/tests/trigger/test_xss.py
+++ b/tests/trigger/test_xss.py
@@ -1,0 +1,15 @@
+from vulnpy.trigger import xss
+from tests.trigger.base_test import BaseTriggerTest
+
+
+class TestRawXss(BaseTriggerTest):
+    @property
+    def trigger_func(self):
+        return xss.do_raw
+
+    @property
+    def good_input(self):
+        return "", ""
+
+    def test_exception(self):
+        pass


### PR DESCRIPTION
Vulnpy can now detect if user input is injected into the response content / body for any of the supported frameworks.

Note that xss does not follow the same pattern as other trigger functions; it doesn't have a trigger function. I considered defining `do_raw`  as
```
def do_raw(user_input):
        template = get_template("{}.html".format(name))

        if name == "xss" and trigger == "raw":
            template += "<p>XSS: " + user_input + "</p>"
        return template

```
but that seemed to cross the line of separation of concerns between triggers and templates. I think the current way makes sense.