### PR TITLE
PYT-1000 Add sqli

### DIFF
--- a/src/vulnpy/templates/cmdi.html
+++ b/src/vulnpy/templates/cmdi.html
@@ -22,6 +22,7 @@
               <li><a href="/vulnpy/hash/">Insecure Hasher</a></li>
               <li><a href="/vulnpy/pt/">Path Traversal</a></li>
               <li><a href="/vulnpy/rand/">Insecure Randomizer</a></li>
+              <li><a href="/vulnpy/sqli/">SQLi</a></li>
               <li><a href="/vulnpy/ssrf/">SSRF</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
               <li><a href="/vulnpy/xss/">XSS</a></li>

--- a/src/vulnpy/templates/deserialization.html
+++ b/src/vulnpy/templates/deserialization.html
@@ -22,6 +22,7 @@
               <li><a href="/vulnpy/hash/">Insecure Hasher</a></li>
               <li><a href="/vulnpy/pt/">Path Traversal</a></li>
               <li><a href="/vulnpy/rand/">Insecure Randomizer</a></li>
+              <li><a href="/vulnpy/sqli/">SQLi</a></li>
               <li><a href="/vulnpy/ssrf/">SSRF</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
               <li><a href="/vulnpy/xss/">XSS</a></li>

--- a/src/vulnpy/templates/fragments/base.html
+++ b/src/vulnpy/templates/fragments/base.html
@@ -21,6 +21,7 @@
               <li><a href="/vulnpy/hash/">Insecure Hasher</a></li>
               <li><a href="/vulnpy/pt/">Path Traversal</a></li>
               <li><a href="/vulnpy/rand/">Insecure Randomizer</a></li>
+              <li><a href="/vulnpy/sqli/">SQLi</a></li>
               <li><a href="/vulnpy/ssrf/">SSRF</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
               <li><a href="/vulnpy/xss/">XSS</a></li>

--- a/src/vulnpy/templates/fragments/sqli.frag.html
+++ b/src/vulnpy/templates/fragments/sqli.frag.html
@@ -1,0 +1,46 @@
+<h1>SQLi: sqlite3.execute</h1>
+
+<form action="/vulnpy/sqli/sqlite3-execute/" method="get">
+  <div class="field has-addons">
+    <div class="control">
+      <input class="input" type="text" name="user_input" placeholder="d', '4'),('e">
+    </div>
+    <div class="control">
+      <button class="button is-info" action="submit">
+        Execute
+      </button>
+    </div>
+  </div>
+</form>
+<br>
+
+<h1>SQLi: sqlite3.executemany</h1>
+
+<form action="/vulnpy/sqli/sqlite3-executemany/" method="get">
+  <div class="field has-addons">
+    <div class="control">
+      <input class="input" type="text" name="user_input" placeholder="d', '4'),('e">
+    </div>
+    <div class="control">
+      <button class="button is-info" action="submit">
+        Execute
+      </button>
+    </div>
+  </div>
+</form>
+<br>
+
+<h1>SQLi: sqlite3.executescript</h1>
+
+<form action="/vulnpy/sqli/sqlite3-executescript/" method="get">
+  <div class="field has-addons">
+    <div class="control">
+      <input class="input" type="text" name="user_input" placeholder="d', '4'),('e">
+    </div>
+    <div class="control">
+      <button class="button is-info" action="submit">
+        Execute
+      </button>
+    </div>
+  </div>
+</form>

--- a/src/vulnpy/templates/hash.html
+++ b/src/vulnpy/templates/hash.html
@@ -22,6 +22,7 @@
               <li><a href="/vulnpy/hash/">Insecure Hasher</a></li>
               <li><a href="/vulnpy/pt/">Path Traversal</a></li>
               <li><a href="/vulnpy/rand/">Insecure Randomizer</a></li>
+              <li><a href="/vulnpy/sqli/">SQLi</a></li>
               <li><a href="/vulnpy/ssrf/">SSRF</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
               <li><a href="/vulnpy/xss/">XSS</a></li>

--- a/src/vulnpy/templates/home.html
+++ b/src/vulnpy/templates/home.html
@@ -22,6 +22,7 @@
               <li><a href="/vulnpy/hash/">Insecure Hasher</a></li>
               <li><a href="/vulnpy/pt/">Path Traversal</a></li>
               <li><a href="/vulnpy/rand/">Insecure Randomizer</a></li>
+              <li><a href="/vulnpy/sqli/">SQLi</a></li>
               <li><a href="/vulnpy/ssrf/">SSRF</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
               <li><a href="/vulnpy/xss/">XSS</a></li>

--- a/src/vulnpy/templates/rand.html
+++ b/src/vulnpy/templates/rand.html
@@ -22,6 +22,7 @@
               <li><a href="/vulnpy/hash/">Insecure Hasher</a></li>
               <li><a href="/vulnpy/pt/">Path Traversal</a></li>
               <li><a href="/vulnpy/rand/">Insecure Randomizer</a></li>
+              <li><a href="/vulnpy/sqli/">SQLi</a></li>
               <li><a href="/vulnpy/ssrf/">SSRF</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
               <li><a href="/vulnpy/xss/">XSS</a></li>

--- a/src/vulnpy/templates/sqli.html
+++ b/src/vulnpy/templates/sqli.html
@@ -34,12 +34,12 @@
       <br>
       <div class="column container">
         <!-- ###vulnpy-injection-site### - do not modify this line; it's in a regex -->
-<h1>Path Traversal: io.open</h1>
+<h1>SQLi: sqlite3.execute</h1>
 
-<form action="/vulnpy/pt/io-open/" method="get">
+<form action="/vulnpy/sqli/sqlite3-execute/" method="get">
   <div class="field has-addons">
     <div class="control">
-      <input class="input" type="text" name="user_input" placeholder="../../etc/passwd">
+      <input class="input" type="text" name="user_input" placeholder="d', '4'),('e">
     </div>
     <div class="control">
       <button class="button is-info" action="submit">
@@ -50,12 +50,12 @@
 </form>
 <br>
 
-<h1>Path Traversal: open</h1>
+<h1>SQLi: sqlite3.executemany</h1>
 
-<form action="/vulnpy/pt/open/" method="get">
+<form action="/vulnpy/sqli/sqlite3-executemany/" method="get">
   <div class="field has-addons">
     <div class="control">
-      <input class="input" type="text" name="user_input" placeholder="../../etc/passwd">
+      <input class="input" type="text" name="user_input" placeholder="d', '4'),('e">
     </div>
     <div class="control">
       <button class="button is-info" action="submit">
@@ -66,12 +66,12 @@
 </form>
 <br>
 
-<h1>Path Traversal: execfile (Python 2 only)</h1>
+<h1>SQLi: sqlite3.executescript</h1>
 
-<form action="/vulnpy/pt/execfile/" method="get">
+<form action="/vulnpy/sqli/sqlite3-executescript/" method="get">
   <div class="field has-addons">
     <div class="control">
-      <input class="input" type="text" name="user_input" placeholder="../../etc/passwd">
+      <input class="input" type="text" name="user_input" placeholder="d', '4'),('e">
     </div>
     <div class="control">
       <button class="button is-info" action="submit">

--- a/src/vulnpy/templates/ssrf.html
+++ b/src/vulnpy/templates/ssrf.html
@@ -22,6 +22,7 @@
               <li><a href="/vulnpy/hash/">Insecure Hasher</a></li>
               <li><a href="/vulnpy/pt/">Path Traversal</a></li>
               <li><a href="/vulnpy/rand/">Insecure Randomizer</a></li>
+              <li><a href="/vulnpy/sqli/">SQLi</a></li>
               <li><a href="/vulnpy/ssrf/">SSRF</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
               <li><a href="/vulnpy/xss/">XSS</a></li>

--- a/src/vulnpy/templates/unsafe_code_exec.html
+++ b/src/vulnpy/templates/unsafe_code_exec.html
@@ -22,6 +22,7 @@
               <li><a href="/vulnpy/hash/">Insecure Hasher</a></li>
               <li><a href="/vulnpy/pt/">Path Traversal</a></li>
               <li><a href="/vulnpy/rand/">Insecure Randomizer</a></li>
+              <li><a href="/vulnpy/sqli/">SQLi</a></li>
               <li><a href="/vulnpy/ssrf/">SSRF</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
               <li><a href="/vulnpy/xss/">XSS</a></li>

--- a/src/vulnpy/templates/xss.html
+++ b/src/vulnpy/templates/xss.html
@@ -22,6 +22,7 @@
               <li><a href="/vulnpy/hash/">Insecure Hasher</a></li>
               <li><a href="/vulnpy/pt/">Path Traversal</a></li>
               <li><a href="/vulnpy/rand/">Insecure Randomizer</a></li>
+              <li><a href="/vulnpy/sqli/">SQLi</a></li>
               <li><a href="/vulnpy/ssrf/">SSRF</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
               <li><a href="/vulnpy/xss/">XSS</a></li>

--- a/src/vulnpy/templates/xxe.html
+++ b/src/vulnpy/templates/xxe.html
@@ -22,6 +22,7 @@
               <li><a href="/vulnpy/hash/">Insecure Hasher</a></li>
               <li><a href="/vulnpy/pt/">Path Traversal</a></li>
               <li><a href="/vulnpy/rand/">Insecure Randomizer</a></li>
+              <li><a href="/vulnpy/sqli/">SQLi</a></li>
               <li><a href="/vulnpy/ssrf/">SSRF</a></li>
               <li><a href="/vulnpy/unsafe_code_exec/">Unsafe Code Execution</a></li>
               <li><a href="/vulnpy/xss/">XSS</a></li>

--- a/src/vulnpy/trigger/__init__.py
+++ b/src/vulnpy/trigger/__init__.py
@@ -12,6 +12,7 @@ DATA = {
     "hash": "hashme",
     "pt": "../../etc/passwd",
     "rand": "seed",
+    "sqli": "d', '4'),('e",
     "ssrf": "attacker.com",
     "unsafe_code_exec": "1 + 2",
     "xss": "attack",

--- a/src/vulnpy/trigger/sqli.py
+++ b/src/vulnpy/trigger/sqli.py
@@ -1,0 +1,60 @@
+import sqlite3
+
+db_connection = sqlite3.connect(":memory:")
+SELECT_ALL = "SELECT * FROM Character"
+
+
+def _db_reset():
+    db_connection.executescript(
+        """
+        DROP TABLE IF EXISTS Character;
+        CREATE TABLE Character(value, count);
+        INSERT INTO Character VALUES
+            ('a', '3'),('b', '5'),('c', '1')
+        """
+    )
+    db_connection.commit()
+
+
+def _execute(db_func):
+    try:
+        _db_reset()
+        cursor = db_connection.cursor()
+        db_func(cursor)
+        all_rows = cursor.execute(SELECT_ALL)
+        return ";".join([",".join(row) for row in all_rows])
+    except Exception:
+        return "<>"
+
+
+EXECUTE_QUERY_FMT = "INSERT INTO Character VALUES ('{}', '1')"
+
+
+def do_sqlite3_execute(user_input):
+    def execute(cursor):
+        sql = EXECUTE_QUERY_FMT.format(user_input)
+        cursor.execute(sql)
+
+    return _execute(execute)
+
+
+EXECUTEMANY_QUERY_FMT = "INSERT INTO Character VALUES ('{}', ?)"
+
+
+def do_sqlite3_executemany(user_input):
+    def executemany(cursor):
+        sql = EXECUTEMANY_QUERY_FMT.format(user_input)
+        cursor.executemany(sql, [("1")])
+
+    return _execute(executemany)
+
+
+EXECUTESCRIPT_QUERY_FMT = "INSERT INTO Character VALUES ('{}', '1'); SELECT 0"
+
+
+def do_sqlite3_executescript(user_input):
+    def executescript(cursor):
+        sql = EXECUTESCRIPT_QUERY_FMT.format(user_input)
+        return cursor.executescript(sql)
+
+    return _execute(executescript)

--- a/src/vulnpy/trigger/sqli.py
+++ b/src/vulnpy/trigger/sqli.py
@@ -24,7 +24,7 @@ def _execute(db_func):
         all_rows = cursor.execute(SELECT_ALL)
         return ";".join([",".join(row) for row in all_rows])
     except Exception:
-        return "<>"
+        return "error"
 
 
 EXECUTE_QUERY_FMT = "INSERT INTO Character VALUES ('{}', '1')"

--- a/tests/trigger/test_sqli.py
+++ b/tests/trigger/test_sqli.py
@@ -1,0 +1,38 @@
+from vulnpy.trigger import sqli
+from tests.trigger.base_test import BaseTriggerTest
+
+
+class BaseSqliTest(BaseTriggerTest):
+    """All SQLi triggers catch their exceptions"""
+
+    @property
+    def exception_input(self):
+        return "invalid ' sql"
+
+    def test_exception(self):
+        pass
+
+    def test_exception_caught(self):
+        assert self.trigger_func(self.exception_input) == "<>"
+
+    @property
+    def good_input(self):
+        return "d', '4'),('e", "a,3;b,5;c,1;d,4;e,1"
+
+
+class TestSqliteExecute(BaseSqliTest):
+    @property
+    def trigger_func(self):
+        return sqli.do_sqlite3_execute
+
+
+class TestSqliteExecutemany(BaseSqliTest):
+    @property
+    def trigger_func(self):
+        return sqli.do_sqlite3_executemany
+
+
+class TestSqliteExecutescript(BaseSqliTest):
+    @property
+    def trigger_func(self):
+        return sqli.do_sqlite3_executescript

--- a/tests/trigger/test_sqli.py
+++ b/tests/trigger/test_sqli.py
@@ -13,7 +13,7 @@ class BaseSqliTest(BaseTriggerTest):
         pass
 
     def test_exception_caught(self):
-        assert self.trigger_func(self.exception_input) == "<>"
+        assert self.trigger_func(self.exception_input) == "error"
 
     @property
     def good_input(self):


### PR DESCRIPTION
This adds triggers for sqlite3 `execute*` methods. I don't think full database + ORM coverage belongs here, but let me know if you think otherwise. Keeping the sqlite3 database in-memory vastly simplifies these new triggers.

I played around with a sort of weird functional design here, which was kind of fun.