### PR TITLE
Add trigger extras install option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,6 @@ setup(
         "falcon": falcon_extras,
         "flask": flask_extras,
         "pyramid": pyramid_extras,
+        "trigger": trigger_extras,
     },
 )


### PR DESCRIPTION
For frameworks we don't directly support here (yet), this provides users with an option to install all trigger dependencies only. This will allow consumers to use `vulnpy.trigger` modules directly without installing any particular framework dependencies.