### PR TITLE
Add WSGI support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ pyramid: templates
 
 django: templates
 	VULNPY_REAL_SSRF_REQUESTS=true python apps/django_app.py runserver $(HOST):$(PORT)
+
+wsgi: templates
+	VULNPY_REAL_SSRF_REQUESTS=true python apps/wsgi_app.py $(HOST) $(PORT)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ app = Falcon.API()
 vulnpy.falcon.add_vulnerable_routes(app)
 ```
 
+### WSGI
+
+Install vulnpy with wsgi extensions:
+
+```
+pip install 'git+git://github.com/Contrast-Security-OSS/vulnpy#egg=vulnpy[wsgi]'
+```
+
+`vulnpy.wsgi.vulnerable_app` is a vulnerable WSGI application. This versatile component
+can be used with a variety of frameworks. For example, Pylons provides a `Cascade` class,
+which can be used to compose WSGI applications serially.
+
 ## Sample Servers
 
 `vulnpy` is intended to extend the functionality of an existing web application. However, for

--- a/apps/wsgi_app.py
+++ b/apps/wsgi_app.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from wsgiref.simple_server import make_server
+
+from vulnpy.wsgi import vulnerable_app
+
+
+def rerouter_middleware(app):
+    """
+    Reroute the root page to /vulnpy/. This is slightly irresponsible because we
+    don't call the wrapped application in this case.
+    """
+
+    def wrapped_application(environ, start_response):
+        if environ["PATH_INFO"] in ("", "/"):
+            start_response("302 FOUND", [("Location", "/vulnpy/")])
+            return [b""]
+        return app(environ, start_response)
+
+    return wrapped_application
+
+
+def make_app():
+    app = rerouter_middleware(vulnerable_app)
+    if os.environ.get("VULNPY_USE_CONTRAST"):
+        from contrast.agent.middlewares.wsgi_middleware import (
+            WSGIMiddleware as ContrastMiddleware,
+        )
+
+        app = ContrastMiddleware(app)
+
+    return app
+
+
+if __name__ == "__main__":
+    host = sys.argv[1] if len(sys.argv) > 1 else "localhost"
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 8000
+
+    app = make_app()
+
+    httpd = make_server(host, port, app)
+    print("WSGI app starting on http://{}:{}".format(host, port))
+    httpd.serve_forever()

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ django_extras = ["Django"] + trigger_extras
 falcon_extras = ["falcon"] + trigger_extras
 flask_extras = ["Flask"] + trigger_extras
 pyramid_extras = ["pyramid"] + trigger_extras
+wsgi_extras = [] + trigger_extras
 
 extra_extras = ["WebTest", "gunicorn", "tox"]
 
@@ -22,6 +23,7 @@ all_extras = (
     + falcon_extras
     + flask_extras
     + pyramid_extras
+    + wsgi_extras
     + extra_extras
     + trigger_extras
 )
@@ -60,6 +62,7 @@ setup(
         "falcon": falcon_extras,
         "flask": flask_extras,
         "pyramid": pyramid_extras,
+        "wsgi": wsgi_extras,
         "trigger": trigger_extras,
     },
 )

--- a/src/vulnpy/wsgi/__init__.py
+++ b/src/vulnpy/wsgi/__init__.py
@@ -1,0 +1,1 @@
+from .app import vulnerable_app  # noqa: F401

--- a/src/vulnpy/wsgi/app.py
+++ b/src/vulnpy/wsgi/app.py
@@ -1,0 +1,95 @@
+from vulnpy.common import get_template
+from vulnpy.trigger import TRIGGER_MAP, get_trigger, xss
+from vulnpy.vendor import six
+
+if six.PY2:
+    from urlparse import parse_qs
+else:
+    from urllib.parse import parse_qs
+
+
+def vulnerable_app(environ, start_response):
+    """
+    A WSGI application callable that exposes vulnpy's API.
+
+    This application currently only supports user_input coming form
+    QUERY_STRING parameters. In the future, it should support form
+    submissions.
+    """
+    response = []
+    try:
+        name, trigger_func = _get_trigger_info(environ)
+    except NotFound:
+        return not_found(start_response)
+
+    if trigger_func:
+        user_input = _get_user_input(environ)
+        trigger_func(user_input)
+        if trigger_func is xss.do_raw:
+            response.append("<p>XSS: {}</p>".format(user_input))
+
+    response.append(get_template("{}.html".format(name)))
+    start_response("200 OK", [("Content-Type", "text/html")])
+    return [six.ensure_binary(s) for s in response]
+
+
+class NotFound(Exception):
+    pass
+
+
+def not_found(start_response):
+    start_response("404 NOT FOUND", [("Content-Type", "text/plain")])
+    return [b"The requested page does not exist"]
+
+
+def _get_user_input(environ):
+    """
+    Get the user_input param, which must be in the querystring.
+    Request body sources are currently unsupported.
+    """
+    return parse_qs(environ["QUERY_STRING"]).get("user_input", [""])[0]
+
+
+def _get_trigger_info(environ):
+    """
+    This method is essentially the router for this application. It gets
+    the vulnerability name and trigger function from the request path.
+    These two values are returned in a 2-tuple.
+
+    If we find an invalid path, raise a NotFound exception.
+    If we find a vulnerability name homepage, such as /vulnpy/cmdi/, the
+    second element of the return value will be None.
+    """
+    path_components = [s for s in environ["PATH_INFO"].split("/") if s != ""]
+    if (
+        len(path_components) < 1
+        or len(path_components) > 3
+        or path_components[0] != "vulnpy"
+    ):
+        raise NotFound()
+    if len(path_components) == 1:
+        return "home", None
+
+    name = path_components[1]
+    if name not in TRIGGER_MAP:
+        raise NotFound()
+    # we need to do this to avoid path traversal during template resolution
+    sanitized_name = [s for s in TRIGGER_MAP.keys() if s == name][0]
+
+    if len(path_components) == 2:
+        return sanitized_name, None
+
+    return sanitized_name, _get_trigger_func(sanitized_name, path_components[2])
+
+
+def _get_trigger_func(name, trigger_name):
+    """
+    Given a valid vulnerability name, get the trigger function corresponding
+    to the vulnerability name and trigger name.
+
+    If the trigger function isn't found, raise NotFound.
+    """
+    try:
+        return get_trigger(name, trigger_name)
+    except AttributeError:
+        raise NotFound()

--- a/tests/wsgi/test_app.py
+++ b/tests/wsgi/test_app.py
@@ -1,0 +1,38 @@
+import pytest
+from webtest import TestApp
+
+from vulnpy.trigger import DATA
+from tests import parametrize_root, parametrize_triggers
+
+from vulnpy.wsgi import vulnerable_app
+
+
+@pytest.fixture(scope="module")
+def client():
+    return TestApp(vulnerable_app)
+
+
+@parametrize_root
+def test_root_views(client, view_path):
+    response = client.get(view_path)
+    assert response.status_int == 200
+
+
+@parametrize_triggers
+def test_trigger(client, view_name, trigger_name):
+    response = client.get(
+        "/vulnpy/{}/{}".format(view_name, trigger_name),
+        {"user_input": DATA[view_name]},
+    )
+    assert response.status_code == 200
+
+    if view_name == "xss":
+        assert "<p>XSS: {}</p>".format(DATA.get(view_name)) in str(response.text)
+
+
+@pytest.mark.parametrize(
+    "path", ["", "/", "/notvulnpy", "/vulnpy/foo", "/vulnpy/cmdi/bar"]
+)
+def test_not_found(client, path):
+    response = client.get(path, status=404)
+    assert response.text == "The requested page does not exist"


### PR DESCRIPTION
This PR adds a pure WSGI application to vulnpy. This works a little differently from using a real framework, since routes aren't registered ahead of time - instead, on each request we parse PATH_INFO and delegate to a trigger function accordingly.

To test this out live, stand up the WSGI app with `make wsgi`.