### PR TITLE
change lxml version for flexibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except IOError:
     README = ""
 
-trigger_extras = ["PyYAML>=5.1", "lxml==4.3.1", "mock==3.*"]
+trigger_extras = ["PyYAML>=5.1", "lxml>=4.3.1", "mock==3.*"]
 
 django_extras = ["Django"] + trigger_extras
 falcon_extras = ["falcon"] + trigger_extras


### PR DESCRIPTION
pipeline that fails like this

```
INFO: pip is looking at multiple versions of flask to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install lxml==4.6.1 and vulnpy[flask]==0.1.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested lxml==4.6.1
    vulnpy[flask] 0.1.0 depends on lxml==4.3.1; extra == "flask"

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```

this should allow for flexibility.