### PR TITLE
Add Dockerfile for contrast-instrumented webservers

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,8 @@
 [flake8]
-max-line-length = 100
+max-line-length = 88
 max-complexity = 5
 ignore =
-    # E203 whitespace before ‘:’ (Not PEP8 compliant, Python Black)
+    # E203 whitespace before ':' (Not PEP8 compliant, Python Black)
     E203
     # W503 line break before binary operator (Not PEP8 compliant, Python Black)
     W503

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .pytest_cache
 .coverage.*
 .coverage
+*.log
 
 # python
 *.pyc
@@ -15,3 +16,7 @@ dist
 
 # other
 .DS_Store
+
+# contrast
+contrast_security.yml
+contrast_security.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+ARG PYTHON_VERSION=3.8
+FROM python:${PYTHON_VERSION}-slim
+
+WORKDIR /vulnpy
+COPY . .
+
+RUN apt-get update && apt-get install -y build-essential autoconf
+RUN pip install -U contrast-agent
+RUN pip install -e .[all]
+
+ENV PORT="3010"
+ENV FRAMEWORK="wsgi"
+ENV HOST="0.0.0.0"
+ENV VULNPY_USE_CONTRAST="true"
+
+ENTRYPOINT make ${FRAMEWORK}

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,22 @@
 HOST ?= localhost
 PORT ?= 8000
 
+export VULNPY_REAL_SSRF_REQUESTS = true
+
 templates:
 	./scripts/gen_templates.sh
 
 flask: templates
-	VULNPY_REAL_SSRF_REQUESTS=true FLASK_APP=apps/flask_app.py flask run --host=$(HOST) --port=$(PORT)
+	FLASK_APP=apps/flask_app.py flask run --host=$(HOST) --port=$(PORT)
 
 falcon: templates
-	VULNPY_REAL_SSRF_REQUESTS=true gunicorn -b $(HOST):$(PORT) apps.falcon_app:app
+	gunicorn -b $(HOST):$(PORT) apps.falcon_app:app
 
 pyramid: templates
-	VULNPY_REAL_SSRF_REQUESTS=true python apps/pyramid_app.py $(HOST):$(PORT)
+	python apps/pyramid_app.py $(HOST):$(PORT)
 
 django: templates
-	VULNPY_REAL_SSRF_REQUESTS=true python apps/django_app.py runserver $(HOST):$(PORT)
+	python apps/django_app.py runserver $(HOST):$(PORT)
 
 wsgi: templates
-	VULNPY_REAL_SSRF_REQUESTS=true python apps/wsgi_app.py $(HOST) $(PORT)
+	python apps/wsgi_app.py $(HOST) $(PORT)

--- a/README.md
+++ b/README.md
@@ -97,10 +97,12 @@ pip install 'git+git://github.com/Contrast-Security-OSS/vulnpy#egg=vulnpy[wsgi]'
 can be used with a variety of frameworks. For example, Pylons provides a `Cascade` class,
 which can be used to compose WSGI applications serially.
 
-## Sample Servers
+### Sample Servers
 
 `vulnpy` is intended to extend the functionality of an existing web application. However, for
 convenience, we provide tiny webapps for each supported framework with `vulnpy` attached.
+
+#### Running Directly
 
 To serve a webapp on your local machine,
 - check out the source repo and `cd` into it
@@ -113,6 +115,22 @@ make (your_framework)
 
 For example, `pip install -e ".[flask]" && make flask` launches a simple flask webapp with vulnpy
 endpoints.
+
+To run with Contrast, install the agent (`pip install -U contrast-agent`) and set
+`VULNPY_USE_CONTRAST=true` before running your desired `make` command.
+
+#### Running with Contrast in Docker
+
+`vulnpy` provides a Dockerfile that is also preconfigured to enable Contrast Security's
+instrumentation. To run a `vulnpy` web server with Contrast enabled using Docker:
+
+1. Copy a `contrast_security.yaml` configuration file into the `vulnpy` root directory
+2. Build the image with `docker build -t vulnpy:latest .` from the `vulnpy` root
+3. Run the container with `docker run --rm -it -p <port>:<port> -e PORT=<port> vulnpy`
+	* Select a value for `<port>` to expose this port on your host machine
+	* Optionally specify your framework with `-e FRAMEWORK=<some_framework>`
+	* Framework options include django, falcon, flask, pyramid, and wsgi (default)
+4. The webserver is now running on your selected port on the host machine
 
 ### Note on SSRF
 

--- a/setup.py
+++ b/setup.py
@@ -8,24 +8,24 @@ try:
 except IOError:
     README = ""
 
-trigger_extras = ["PyYAML>=5.1", "lxml>=4.3.1", "mock==3.*"]
+# NOTE: a typical webserver is included with framework dependencies if necessary
+trigger_extras = {"PyYAML>=5.1", "lxml>=4.3.1", "mock==3.*"}
+django_extras = {"Django"} | trigger_extras
+falcon_extras = {"falcon", "gunicorn"} | trigger_extras
+flask_extras = {"Flask"} | trigger_extras
+pyramid_extras = {"pyramid", "waitress"} | trigger_extras
+wsgi_extras = trigger_extras
 
-django_extras = ["Django"] + trigger_extras
-falcon_extras = ["falcon"] + trigger_extras
-flask_extras = ["Flask"] + trigger_extras
-pyramid_extras = ["pyramid"] + trigger_extras
-wsgi_extras = [] + trigger_extras
-
-extra_extras = ["WebTest", "gunicorn", "tox"]
+dev_extras = {"WebTest", "gunicorn", "tox"}
 
 all_extras = (
-    django_extras
-    + falcon_extras
-    + flask_extras
-    + pyramid_extras
-    + wsgi_extras
-    + extra_extras
-    + trigger_extras
+    trigger_extras
+    | django_extras
+    | falcon_extras
+    | flask_extras
+    | pyramid_extras
+    | wsgi_extras
+    | dev_extras
 )
 
 setup(


### PR DESCRIPTION
## Overview

* Adds a Dockerfile and instructions to the README. This file creates an image that can be used to run any of our sample webservers
* Made some assorted cleanup to build-related files during this process

## Additional details

* The exact architecture / location of the Dockerfile may change very soon, since we'll be using this for internal testing and development
* If you want to test this for yourself, follow the new instructions in the README