### PR TITLE
Update Dockerfile to use flask by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 ARG PYTHON_VERSION=3.8
 FROM python:${PYTHON_VERSION}-slim
 
+RUN apt-get update && apt-get install -y build-essential autoconf
+RUN pip install -U contrast-agent
+
 WORKDIR /vulnpy
 COPY . .
 
-RUN apt-get update && apt-get install -y build-essential autoconf
-RUN pip install -U contrast-agent
 RUN pip install -e .[all]
 
 ENV PORT="3010"
-ENV FRAMEWORK="wsgi"
+ENV FRAMEWORK="flask"
 ENV HOST="0.0.0.0"
 ENV VULNPY_USE_CONTRAST="true"
 
-ENTRYPOINT make ${FRAMEWORK}
+CMD make ${FRAMEWORK}

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To run with Contrast, install the agent (`pip install -U contrast-agent`) and se
 instrumentation. To run a `vulnpy` web server with Contrast enabled using Docker:
 
 1. Copy a `contrast_security.yaml` configuration file into the `vulnpy` root directory
-2. Build the image with `docker build -t vulnpy:latest .` from the `vulnpy` root
+2. Build the image with `docker build -t vulnpy .` from the `vulnpy` root
 3. Run the container with `docker run --rm -it -p <port>:<port> -e PORT=<port> vulnpy`
 	* Select a value for `<port>` to expose this port on your host machine
 	* Optionally specify your framework with `-e FRAMEWORK=<some_framework>`


### PR DESCRIPTION
We don't get route coverage in `wsgi`, so it's not a great default framework here. In my opinion, flask has the best server logs, so I went with that instead.

I also rearranged the Dockerfile a little to reduce build times when iterating on `vulnpy`.