### PR TITLE
Add "vulnpy-" to route names to minimize conflicts

### DIFF
--- a/src/vulnpy/pyramid/vulnerable_routes.py
+++ b/src/vulnpy/pyramid/vulnerable_routes.py
@@ -23,11 +23,11 @@ def get_trigger_pattern(name, trigger):
 def get_root_name(name):
     if name == "home":
         return "vulnpy-root"
-    return name
+    return "vulnpy-{}".format(name)
 
 
 def get_trigger_name(name, trigger):
-    return "{}-{}".format(name, trigger)
+    return "vulnpy-{}-{}".format(name, trigger)
 
 
 def gen_root_view(name):


### PR DESCRIPTION
The pyramid router behaves differently when routes have the same name. Some of the routes we were generating had names that were likely to conflict with the application's, such as `xss`, `sqli`, etc.

This PR adds `vulnpy-` to the beginning of every route name in pyramid. This dramatically decreases the probability that vulnpy's route names will conflict with the appliction's.