### PR TITLE
make connection in the same thread

### DIFF
--- a/src/vulnpy/trigger/sqli.py
+++ b/src/vulnpy/trigger/sqli.py
@@ -1,6 +1,6 @@
 import sqlite3
 
-db_connection = sqlite3.connect(":memory:")
+db_connection = sqlite3.connect(":memory:", check_same_thread=False)
 SELECT_ALL = "SELECT * FROM Character"
 
 


### PR DESCRIPTION
While creating `db_connection` only once seems clean and works with pytest, actually running a live app fails with `ProgrammingError: SQLite objects created in a thread can only be used in that same thread`. suggested solution [here](https://stackoverflow.com/questions/48218065/programmingerror-sqlite-objects-created-in-a-thread-can-only-be-used-in-that-sa) is to create the connection when you're going to use it.

Tested both live and in pytest and it works as I would expect.