### PR TITLE
get host/port for bottle

### DIFF
--- a/apps/bottle_app.py
+++ b/apps/bottle_app.py
@@ -1,3 +1,4 @@
+import sys
 from bottle import Bottle, run, redirect
 from vulnpy.bottle import add_vulnerable_routes
 
@@ -21,4 +22,7 @@ class StripPathMiddleware(object):
 
 
 if __name__ == "__main__":
-    run(app=StripPathMiddleware(app))
+    host = sys.argv[1] if len(sys.argv) > 1 else "localhost"
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 8000
+
+    run(app=StripPathMiddleware(app), host=host, port=port)


### PR DESCRIPTION
We were missing host/port values when running a live app so it was using bottle's defaults.