### PR TITLE
pin dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,27 @@ except IOError:
 
 # NOTE: a typical webserver is included with framework dependencies if necessary
 trigger_extras = {"PyYAML>=5.1", "lxml>=4.3.1", "mock==3.*"}
-django_extras = {"Django"} | trigger_extras
-falcon_extras = {"falcon", "gunicorn", "uwsgi"} | trigger_extras
-flask_extras = {"Flask"} | trigger_extras
-pyramid_extras = {"pyramid", "waitress"} | trigger_extras
-wsgi_extras = trigger_extras
-bottle_extras = {"bottle"} | trigger_extras
+django_extras = {
+    "Django==1.*; python_version <'3.6'",
+    "Django==3.*; python_version >='3.6'",
+} | trigger_extras
+falcon_extras = {
+    "falcon==2.*",
+    "gunicorn==19.*; python_version <'3.6'",
+    "gunicorn==20.1; python_version >='3.6'",
+    "uwsgi==2.0.*",
+} | trigger_extras
+flask_extras = {"Flask==1.*"} | trigger_extras
+pyramid_extras = {
+    "pyramid==1.*",
+    "waitress==1.0.*; python_version <'3.6'",
+    "waitress==2.0.*; python_version >='3.6'",
+} | trigger_extras
 
-dev_extras = {"WebTest", "gunicorn", "tox"}
+wsgi_extras = trigger_extras
+bottle_extras = {"bottle==0.*"} | trigger_extras
+
+dev_extras = {"WebTest==2.0.*", "tox==3.*"}
 
 all_extras = (
     trigger_extras


### PR DESCRIPTION
pinning versions
- framework versions are pinned to greatest major version currently supported by the contrast agent
- other versions I pinned to prevent failures, we can up them later

to test, I created a new env and pip installed -e .[all], it worked!
```
Successfully installed Django-3.2 Flask-1.1.2 Jinja2-2.11.3 MarkupSafe-1.1.1 PasteDeploy-2.1.1 PyYAML-5.4.1 WebTest-2.0.35 Werkzeug-1.0.1 appdirs-1.4.4 asgiref-3.3.3 beautifulsoup4-4.9.3 bottle-0.12.19 click-7.1.2 distlib-0.3.1 falcon-2.0.0 filelock-3.0.12 gunicorn-20.1.0 hupper-1.10.2 itsdangerous-1.1.0 lxml-4.6.3 mock-3.0.5 packaging-20.9 plaster-1.0 plaster-pastedeploy-0.7 pluggy-0.13.1 py-1.10.0 pyparsing-2.4.7 pyramid-1.10.8 pytz-2021.1 six-1.15.0 soupsieve-2.2.1 sqlparse-0.4.1 toml-0.10.2 tox-3.23.0 translationstring-1.4 uwsgi-2.0.19.1 venusian-3.0.0 virtualenv-20.4.3 vulnpy waitress-2.0.0 webob-1.8.7 zope.deprecation-4.4.0 zope.interface-5.3.0
```