### PR TITLE
PYT-1556 vulnpy now installs flask versions less than 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ falcon_extras = {
     "uwsgi==2.0.*",
     "falcon-multipart==0.2.0",
 } | trigger_extras
-flask_extras = {"Flask<2"} | trigger_extras
+flask_extras = {"Flask<3"} | trigger_extras
 pyramid_extras = {"pyramid<2", "waitress<2.1"} | trigger_extras
 
 wsgi_extras = trigger_extras


### PR DESCRIPTION
As part of adding support for Flask 2.X we need to make sure vulnpy uses the correct version. If we do not add support when running the Flask 2.X framework tests we get this error:
```
ERROR: Cannot install Flask==2.0.0 and vulnpy[flask]==0.1.0 because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested Flask==2.0.0
    vulnpy[flask] 0.1.0 depends on Flask<2; extra == "flask"
To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```