### PR TITLE
PYT-1547 added User-Input header to send data to a trigger

### DIFF
--- a/src/vulnpy/flask/blueprint.py
+++ b/src/vulnpy/flask/blueprint.py
@@ -7,6 +7,9 @@ vulnerable_blueprint = Blueprint("vulnpy", __name__, url_prefix="/vulnpy")
 
 
 def _get_user_input():
+    if request.headers.get("User-Input") is not None:
+        return request.headers.get("User-Input")
+
     if request.method == "GET":
         return request.args.get("user_input", "")
     return request.form.get("user_input", "")

--- a/tests/flask/test_blueprint.py
+++ b/tests/flask/test_blueprint.py
@@ -39,3 +39,11 @@ def test_trigger(client, request_method, view_name, trigger_name):
 
     if view_name == "xss":
         assert "<p>XSS: {}</p>".format(data) in str(response.get_data())
+
+
+def test_trigger_header_source(client):
+    data = DATA["cmdi"]
+
+    response = client.get("/vulnpy/cmdi/os-system", headers={"user_input": data})
+
+    assert response.status_code == 200


### PR DESCRIPTION
This adds the ability to accept user input from a header named user-input. 

The purpose of this change was to test the source tracking changes made as part of this ticket: https://contrast.atlassian.net/browse/PYT-1547