### PR TITLE
PYT-1580 vulnpy now installs falcon versions less than 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          sudo apt-get install libxml2-dev libxslt-dev python-dev
+          sudo apt-get update && sudo apt-get install libxml2-dev libxslt-dev python-dev
           python -m pip install --upgrade pip
           pip install tox
       - name: Run unit tests

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except IOError:
 trigger_extras = {"PyYAML>=5.1", "lxml>=4.3.1", "mock==3.*"}
 django_extras = {"Django<4"} | trigger_extras
 falcon_extras = {
-    "falcon<3",
+    "falcon<4",
     "gunicorn<20.2",
     "uwsgi==2.0.*",
     "falcon-multipart==0.2.0",

--- a/src/vulnpy/trigger/__init__.py
+++ b/src/vulnpy/trigger/__init__.py
@@ -17,7 +17,7 @@ DATA = {
     # against the REDOS regex may be be hardcoded.
     "sqli": "d', '4'),('e",
     "ssrf": "attacker.com",
-    "unsafe_code_exec": "1 + 2",
+    "unsafe_code_exec": "1 - 2",
     "xss": "attack",
     "xxe": "<root>attack</root>",
     "xpath": "./planet[name='Kepler']",

--- a/tests/falcon/test_vulnerable.py
+++ b/tests/falcon/test_vulnerable.py
@@ -1,7 +1,6 @@
 import mock
 import pytest
 import falcon
-from vulnpy.vendor.six.moves.urllib_parse import quote
 
 from falcon import testing
 
@@ -31,9 +30,6 @@ def test_trigger(client, request_method, view_name, trigger_name):
     get_or_post = getattr(client, request_method)
 
     data = DATA[view_name]
-
-    # to make unsafe_code_exec trigger work
-    data = quote(data)
 
     response = get_or_post(
         "/vulnpy/{}/{}".format(view_name, trigger_name), params={"user_input": data},


### PR DESCRIPTION
Just like with flask 2 support we need to update the minimum required version for falcon.

Heres the error message I got when running installation steps locally:
```
Collecting Falcon==3.0
  Using cached falcon-3.0.0-cp39-cp39-macosx_10_14_x86_64.whl (2.1 MB)
Collecting pymongo==3.11.0
  Using cached pymongo-3.11.0-cp39-cp39-macosx_10_9_x86_64.whl
Requirement already satisfied: falcon-multipart==0.2.0 in /Users/nicholasliccione/opt/miniconda3/envs/fw-test-falcon3-py39/lib/python3.9/site-packages (from vulnpy[falcon]->-r requirements-3.0.txt (line 4)) (0.2.0)
Requirement already satisfied: lxml>=4.3.1 in /Users/nicholasliccione/opt/miniconda3/envs/fw-test-falcon3-py39/lib/python3.9/site-packages (from vulnpy[falcon]->-r requirements-3.0.txt (line 4)) (4.6.3)
ERROR: Cannot install Falcon==3.0 and vulnpy[falcon]==0.1.0 because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested Falcon==3.0
    vulnpy[falcon] 0.1.0 depends on falcon<3; extra == "falcon"
To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```