### PR TITLE
PYT-1586 Make good input test more flexible

### DIFF
--- a/tests/trigger/base_test.py
+++ b/tests/trigger/base_test.py
@@ -1,5 +1,7 @@
 import pytest
 
+import operator
+
 
 class BaseTriggerTest(object):
     @property
@@ -25,7 +27,12 @@ class BaseTriggerTest(object):
         return TypeError
 
     def test_good_input(self):
-        assert self.trigger_func(self.good_input[0]) == self.good_input[1]
+        result = self.trigger_func(self.good_input[0])
+        expected = self.good_input[1]
+        compare = operator.eq
+        if len(self.good_input) == 3:
+            compare = self.good_input[2]
+        assert compare(result, expected)
 
     def test_exception(self):
         with pytest.raises(self.exception_raised):


### PR DESCRIPTION
Makes trigger unit tests more flexible by allowing tests to use a custom comparison operator.

Example use:
```
@property
def good_input(self):
    return "echo hacked", int, isinstance
```
The third argument is a binary operator that takes the other two args as its args. It should return a boolean indicating whether the input produced some expected form of output. In the above example, `isinstance(os.system("echo hacked"), int)` is `True`