### PR TITLE
Roll back falcon max version to <3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          sudo apt-get install libxml2-dev libxslt-dev python-dev
+          sudo apt-get update && sudo apt-get install libxml2-dev libxslt-dev python-dev
           python -m pip install --upgrade pip
           pip install tox
       - name: Run unit tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install libxml2-dev libxslt-dev python-dev
+          sudo apt-get install libxml2-dev libxslt-dev python-dev
           python -m pip install --upgrade pip
           pip install tox
       - name: Run unit tests

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except IOError:
 trigger_extras = {"PyYAML>=5.1", "lxml>=4.3.1", "mock==3.*"}
 django_extras = {"Django<4"} | trigger_extras
 falcon_extras = {
-    "falcon<4",
+    "falcon<3",
     "gunicorn<20.2",
     "uwsgi==2.0.*",
     "falcon-multipart==0.2.0",

--- a/src/vulnpy/trigger/__init__.py
+++ b/src/vulnpy/trigger/__init__.py
@@ -17,7 +17,7 @@ DATA = {
     # against the REDOS regex may be be hardcoded.
     "sqli": "d', '4'),('e",
     "ssrf": "attacker.com",
-    "unsafe_code_exec": "1 - 2",
+    "unsafe_code_exec": "1 + 2",
     "xss": "attack",
     "xxe": "<root>attack</root>",
     "xpath": "./planet[name='Kepler']",

--- a/tests/falcon/test_vulnerable.py
+++ b/tests/falcon/test_vulnerable.py
@@ -1,6 +1,7 @@
 import mock
 import pytest
 import falcon
+from vulnpy.vendor.six.moves.urllib_parse import quote
 
 from falcon import testing
 
@@ -30,6 +31,9 @@ def test_trigger(client, request_method, view_name, trigger_name):
     get_or_post = getattr(client, request_method)
 
     data = DATA[view_name]
+
+    # to make unsafe_code_exec trigger work
+    data = quote(data)
 
     response = get_or_post(
         "/vulnpy/{}/{}".format(view_name, trigger_name), params={"user_input": data},


### PR DESCRIPTION
Had to roll back changes made for falcon 3 support due to integration test failures. 

I left the `sudo apt-get update` command because the pipeline failed due to it trying to install deps that didn't exist at the location it tried to install from. 