### PR TITLE
add uwsgi serving for all frameworks and update code to make it work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,23 +16,38 @@ flask-two-apps: templates
 falcon: templates
 	gunicorn -b $(HOST):$(PORT) --timeout=0 apps.falcon_app:app
 
+falcon-uwsgi: templates
+	uwsgi -w apps.falcon_app:app --enable-threads --single-interpreter --http $(HOST):$(PORT)
+
 flask-uwsgi: templates
 	uwsgi -w apps.flask_app:app --enable-threads --single-interpreter --http $(HOST):$(PORT)
 
 pyramid: templates
 	python apps/pyramid_app.py $(HOST):$(PORT)
 
+pyramid-uwsgi: templates
+	uwsgi -w apps.pyramid_app:app --enable-threads --single-interpreter --http $(HOST):$(PORT)
+
 django: templates
 	python apps/django_app.py runserver $(HOST):$(PORT)
 
+# django-uwsgi: templates
+	#uwsgi -w apps.django_app ...
+
 wsgi: templates
 	python apps/wsgi_app.py $(HOST) $(PORT)
+
+wsgi-uwsgi: templates
+	uwsgi -w apps.wsgi_app:app --enable-threads --single-interpreter --http $(HOST):$(PORT)
 
 wsgi-two-apps: templates
 	python apps/wsgi_two_apps.py $(HOST) $(PORT)
 
 bottle: templates
 	python apps/bottle_app.py $(HOST) $(PORT)
+
+bottle-uwsgi: templates
+	uwsgi -w apps.bottle_app:app --enable-threads --single-interpreter --http $(HOST):$(PORT)
 
 # why does this not work?
 fastapi: templates

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ pyramid-uwsgi: templates
 django: templates
 	python apps/django_app.py runserver $(HOST):$(PORT)
 
+# #TODO: PYT-1697
 # django-uwsgi: templates
 	#uwsgi -w apps.django_app ...
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ endpoints.
 To run with Contrast, install the agent (`pip install -U contrast-agent`) and set
 `VULNPY_USE_CONTRAST=true` before running your desired `make` command.
 
+#### Running Different Servers
+
+While some frameworks come with their own servers, you can use the uWSGI server as 
+well. `pip install -e ".[flask,uwsgi]" && make flask-uwsgi` launches the flask app 
+with uWSGI.
+
 #### Running with Contrast in Docker
 
 `vulnpy` provides a Dockerfile that is also preconfigured to enable Contrast Security's

--- a/apps/bottle_app.py
+++ b/apps/bottle_app.py
@@ -22,13 +22,13 @@ class StripPathMiddleware(object):
         return self.app(environ, start_response)
 
 
+if os.environ.get("VULNPY_USE_CONTRAST"):
+    from contrast.bottle import ContrastMiddleware
+
+    app = ContrastMiddleware(app)
+
 if __name__ == "__main__":
     host = sys.argv[1] if len(sys.argv) > 1 else "localhost"
     port = int(sys.argv[2]) if len(sys.argv) > 2 else 8000
-
-    if os.environ.get("VULNPY_USE_CONTRAST"):
-        from contrast.bottle import ContrastMiddleware
-
-        app = ContrastMiddleware(app)
 
     run(app=StripPathMiddleware(app), host=host, port=port)

--- a/apps/pyramid_app.py
+++ b/apps/pyramid_app.py
@@ -10,19 +10,20 @@ def index(request):
     return HTTPFound(location="/vulnpy")
 
 
+with Configurator() as config:
+    config.include("vulnpy.pyramid.vulnerable_routes")
+    config.add_route("index", "/")
+    config.add_view(index, route_name="index")
+
+    if os.environ.get("VULNPY_USE_CONTRAST"):
+        # TODO: be able to import as "contrast.pyramid.ContrastMiddleware"
+        config.add_tween(
+            "contrast.agent.middlewares.pyramid_middleware.PyramidMiddleware"
+        )
+
+    app = config.make_wsgi_app()
+
+
 if __name__ == "__main__":
     host, port = sys.argv[1].split(":")
-    with Configurator() as config:
-        config.include("vulnpy.pyramid.vulnerable_routes")
-        config.add_route("index", "/")
-        config.add_view(index, route_name="index")
-
-        if os.environ.get("VULNPY_USE_CONTRAST"):
-            # TODO: be able to import as "contrast.pyramid.ContrastMiddleware"
-            config.add_tween(
-                "contrast.agent.middlewares.pyramid_middleware.PyramidMiddleware"
-            )
-
-        app = config.make_wsgi_app()
-
     serve(app, host=host, port=int(port))

--- a/apps/wsgi_app.py
+++ b/apps/wsgi_app.py
@@ -30,11 +30,11 @@ def make_app():
     return app
 
 
+app = make_app()
+
 if __name__ == "__main__":
     host = sys.argv[1] if len(sys.argv) > 1 else "localhost"
     port = int(sys.argv[2]) if len(sys.argv) > 2 else 8000
-
-    app = make_app()
 
     httpd = make_server(host, port, app)
     print("WSGI app starting on http://{}:{}".format(host, port))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ fastapi_extras = {
     "fastapi==0.68.0; python_version >= '3.6'",
     "uvicorn[standard]; python_version >= '3.6'",
 } | trigger_extras
-uwsgi_extras = {"uwsgi==2.0.*"} | flask_extras
+uwsgi_extras = {"uwsgi==2.0.*"}
 pyramid_extras = {"pyramid<2", "waitress<2.1"} | trigger_extras
 
 wsgi_extras = trigger_extras


### PR DESCRIPTION
Almost all the contrast supported frameworks can use uwsgi right off the bat - the only changes needed to happen in the *_app.py files themselves to put the app initialization code outside of the if main check. I don't love it (I like the main check), but if I wanted to keep that I would've had to make a second file. Nah....

I ran every single existing app locally to make sure I didn't break anything.