### PR TITLE
fastapi allow for Contrast middleware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ bottle-uwsgi: templates
 	uwsgi -w apps.bottle_app:app --enable-threads --single-interpreter --http $(HOST):$(PORT)
 
 fastapi: templates
-	uvicorn apps.fastapi_app:app
+	uvicorn apps.fastapi_app:app --host=$(HOST) --port=$(PORT)

--- a/apps/fastapi_app.py
+++ b/apps/fastapi_app.py
@@ -10,11 +10,10 @@ from vulnpy.fastapi import vulnerable_routes
 app = FastAPI()
 app.include_router(vulnerable_routes)
 
-# TODO: PYT-1701
-# if os.environ.get("VULNPY_USE_CONTRAST"):
-#     from contrast.fastapi import ContrastMiddleware
-#
-#     app.middleware("http")(ContrastMiddleware(app))
+if os.environ.get("VULNPY_USE_CONTRAST"):
+    from contrast.fastapi import ContrastMiddleware
+
+    app.add_middleware(ContrastMiddleware, original_app=app)
 
 
 @app.get("/")


### PR DESCRIPTION
Allow a fastapi app to use contrast and makefile to get host/port

Contrast middleware API is not out yet, but I'm designing it separately. Currently it needs the `original_app` as an argument