### PR TITLE
PYT-1697 Enable alternate WSGI servers for django app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 HOST ?= localhost
 PORT ?= 8000
+UWSGI_OPTIONS := --enable-threads --single-interpreter --http $(HOST):$(PORT)
+GUNICORN_OPTIONS := --timeout=0 -b $(HOST):$(PORT)
 
 export VULNPY_REAL_SSRF_REQUESTS = true
 
@@ -14,55 +16,55 @@ flask-two-apps: templates
 
 # note: vulnpy's routing strategy for falcon is quite nonstandard
 falcon: templates
-	gunicorn -b $(HOST):$(PORT) --timeout=0 apps.falcon_app:app
+	gunicorn $(GUNICORN_OPTIONS) apps.falcon_app:app
 
 falcon-uwsgi: templates
-	uwsgi -w apps.falcon_app:app --enable-threads --single-interpreter --http $(HOST):$(PORT)
+	uwsgi $(UWSGI_OPTIONS) -w apps.falcon_app:app
 
 flask-uwsgi: templates
-	uwsgi -w apps.flask_app:app --enable-threads --single-interpreter --http $(HOST):$(PORT)
+	uwsgi $(UWSGI_OPTIONS) -w apps.flask_app:app
 
 flask-gunicorn: templates
-	gunicorn -b $(HOST):$(PORT) --timeout=0 apps.flask_app:app
+	gunicorn $(GUNICORN_OPTIONS) apps.flask_app:app
 
 pyramid: templates
 	python apps/pyramid_app.py $(HOST):$(PORT)
 
 pyramid-uwsgi: templates
-	uwsgi -w apps.pyramid_app:app --enable-threads --single-interpreter --http $(HOST):$(PORT)
+	uwsgi $(UWSGI_OPTIONS) -w apps.pyramid_app:app
 
 pyramid-gunicorn: templates
-	gunicorn -b $(HOST):$(PORT) --timeout=0 apps.pyramid_app:app
+	gunicorn $(GUNICORN_OPTIONS) apps.pyramid_app:app
 
 django: templates
-	python apps/django_app.py runserver $(HOST):$(PORT)
+	python apps/django_app.py runserver --noreload $(HOST):$(PORT)
 
-# #TODO: PYT-1697
-# django-uwsgi: templates
-	#uwsgi -w apps.django_app ...
-# django-gunicorn: templates
-#	gunicorn -b $(HOST):$(PORT) --timeout=0 apps.django_app:app
+django-uwsgi: templates
+	uwsgi $(UWSGI_OPTIONS) -w apps.django_app:application
+
+django-gunicorn: templates
+	gunicorn $(GUNICORN_OPTIONS) apps.django_app:application
 
 wsgi: templates
 	python apps/wsgi_app.py $(HOST) $(PORT)
 
 wsgi-uwsgi: templates
-	uwsgi -w apps.wsgi_app:app --enable-threads --single-interpreter --http $(HOST):$(PORT)
+	uwsgi $(UWSGI_OPTIONS) -w apps.wsgi_app:app
 
 wsgi-two-apps: templates
 	python apps/wsgi_two_apps.py $(HOST) $(PORT)
 
 wsgi-gunicorn: templates
-	gunicorn -b $(HOST):$(PORT) --timeout=0 apps.wsgi_app:app
+	gunicorn $(GUNICORN_OPTIONS) apps.wsgi_app:app
 
 bottle: templates
 	python apps/bottle_app.py $(HOST) $(PORT)
 
 bottle-uwsgi: templates
-	uwsgi -w apps.bottle_app:app --enable-threads --single-interpreter --http $(HOST):$(PORT)
+	uwsgi $(UWSGI_OPTIONS) -w apps.bottle_app:app
 
 bottle-gunicorn: templates
-	gunicorn -b $(HOST):$(PORT) --timeout=0 apps.bottle_app:app
+	gunicorn $(GUNICORN_OPTIONS) apps.bottle_app:app
 
 fastapi: templates
 	uvicorn apps.fastapi_app:app --host=$(HOST) --port=$(PORT)

--- a/apps/django_app.py
+++ b/apps/django_app.py
@@ -1,9 +1,9 @@
 import os
 import sys
 
-import django
 from django.conf import settings
-from django.core.management import execute_from_command_line
+from django.core import management
+from django.core.wsgi import get_wsgi_application
 from django.shortcuts import redirect
 
 try:
@@ -18,28 +18,22 @@ urlpatterns = [
     compat_url(r"^$", lambda r: redirect("/vulnpy"))
 ] + vulnerable_urlpatterns
 
-filename = os.path.basename(os.path.splitext(__file__)[0])
+if not settings.configured:
+    settings.configure(
+        **{
+            "ROOT_URLCONF": "django_app"
+            if __name__ == "__main__"
+            else "apps.django_app",
+            "ALLOWED_HOSTS": ["localhost", "127.0.0.1", "[::1]"],
+        }
+    )
+
+application = get_wsgi_application()
+
+if os.environ.get("VULNPY_USE_CONTRAST"):
+    from contrast.django import ContrastMiddleware
+
+    application = ContrastMiddleware(application)
 
 if __name__ == "__main__":
-
-    options = {
-        "ROOT_URLCONF": filename,
-        "ALLOWED_HOSTS": ["localhost", "127.0.0.1", "[::1]"],
-    }
-
-    if os.environ.get("VULNPY_USE_CONTRAST"):
-        # TODO: be able to import as "contrast.django.ContrastMiddleware"
-        if django.VERSION < (1, 10):
-            middleware_setting_name = "MIDDLEWARE_CLASSES"
-            contrast_middleware_name = (
-                "contrast.agent.middlewares.legacy_django_middleware.DjangoMiddleware"
-            )
-        else:
-            middleware_setting_name = "MIDDLEWARE"
-            contrast_middleware_name = (
-                "contrast.agent.middlewares.django_middleware.DjangoMiddleware"
-            )
-        options[middleware_setting_name] = [contrast_middleware_name]
-
-    settings.configure(**options)
-    execute_from_command_line(sys.argv)
+    management.execute_from_command_line(sys.argv)


### PR DESCRIPTION
_Lets us use gunicorn and uwsgi to start up the sample Django app_

Our django app wasn't exposing a WSGI application callable, because it was relying completely on django internals. As such, we couldn't use any server other than the default django server to start up this app. Here's what I did to make this work:

- added a call to `django.core.wsgi.get_wsgi_application`
- replaced the django-style middlewares with our django-wsgi middleware
- made some Makefile cleanups to reduce some duplication

I had to do a fair amount of trial and error to get this exactly right, but all of our integration tests passed (internal link: https://github.com/Contrast-Security-Inc/python-agent/runs/3537765004?check_suite_focus=true)