### PR TITLE
define route name

### DIFF
--- a/src/vulnpy/fastapi/vulnerable.py
+++ b/src/vulnpy/fastapi/vulnerable.py
@@ -22,7 +22,7 @@ def get_trigger_name(name, trigger):
 def gen_root_view(name):
     view_name = get_root_name(name)
 
-    @router.get(view_name)
+    @router.get(path=view_name, name=view_name)
     async def _view():
         return HTMLResponse(get_template("{}.html".format(name)))
 
@@ -30,7 +30,7 @@ def gen_root_view(name):
 def get_trigger_view(name, trigger):
     view_name = get_trigger_name(name, trigger)
 
-    @router.get(view_name)
+    @router.get(path=view_name, name=view_name)
     async def _view(user_input: str):
         trigger_func = get_trigger(name, trigger)
 


### PR DESCRIPTION
FastAPI routing machinery to define the route name so not all routes have the same name.