### PR TITLE
PYT-1635 Remove falcon make target in favor of falcon-gunicorn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,24 +8,27 @@ export VULNPY_REAL_SSRF_REQUESTS = true
 templates:
 	./scripts/gen_templates.sh
 
-flask: templates
-	FLASK_APP=apps/flask_app.py flask run --host=$(HOST) --port=$(PORT)
-
-flask-two-apps: templates
-	FLASK_APP=apps/flask_two_apps.py:combined_app flask run --host=$(HOST) --port=$(PORT)
-
-# note: vulnpy's routing strategy for falcon is quite nonstandard
-falcon: templates
-	gunicorn $(GUNICORN_OPTIONS) apps.falcon_app:app
+falcon: # falcon has no default server, so we use gunicorn
+	$(error Falcon requires a production webserver - try `make falcon-gunicorn`)
 
 falcon-uwsgi: templates
 	uwsgi $(UWSGI_OPTIONS) -w apps.falcon_app:app
+
+# note: vulnpy's routing strategy for falcon is quite nonstandard
+falcon-gunicorn: templates
+	gunicorn $(GUNICORN_OPTIONS) apps.falcon_app:app
+
+flask: templates
+	FLASK_APP=apps/flask_app.py flask run --host=$(HOST) --port=$(PORT)
 
 flask-uwsgi: templates
 	uwsgi $(UWSGI_OPTIONS) -w apps.flask_app:app
 
 flask-gunicorn: templates
 	gunicorn $(GUNICORN_OPTIONS) apps.flask_app:app
+
+flask-two-apps: templates
+	FLASK_APP=apps/flask_two_apps.py:combined_app flask run --host=$(HOST) --port=$(PORT)
 
 pyramid: templates
 	python apps/pyramid_app.py $(HOST):$(PORT)
@@ -51,11 +54,11 @@ wsgi: templates
 wsgi-uwsgi: templates
 	uwsgi $(UWSGI_OPTIONS) -w apps.wsgi_app:app
 
-wsgi-two-apps: templates
-	python apps/wsgi_two_apps.py $(HOST) $(PORT)
-
 wsgi-gunicorn: templates
 	gunicorn $(GUNICORN_OPTIONS) apps.wsgi_app:app
+
+wsgi-two-apps: templates
+	python apps/wsgi_two_apps.py $(HOST) $(PORT)
 
 bottle: templates
 	python apps/bottle_app.py $(HOST) $(PORT)

--- a/README.md
+++ b/README.md
@@ -160,9 +160,13 @@ To run with Contrast, install the agent (`pip install -U contrast-agent`) and se
 #### Running Different Servers
 
 While some frameworks come with their own servers, you can use the uWSGI or 
-gunicorn servers as well. `pip install -e ".[flask,uwsgi]" && make flask-uwsgi` launches
-the flask app with uWSGI. `pip install -e ".[falcon,gunicorn]" && make falcon` will
-launch the falcon app with gunicorn.
+gunicorn servers as well.
+
+`pip install -e ".[flask,uwsgi-max]" && make flask-uwsgi`
+launches the flask app with the maximum supported uWSGI version.
+
+`pip install -e ".[falcon,gunicorn-min]" && make falcon-gunicorn`
+launches the falcon app with the minimum supported gunicorn version.
 
 #### Running with Contrast in Docker
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ try:
 except IOError:
     README = ""
 
-# NOTE: a typical webserver is included with framework dependencies if necessary
 trigger_extras = {"PyYAML>=5.1", "lxml>=4.3.1", "mock==3.*"}
 django_extras = {"Django<4"} | trigger_extras
 falcon_extras = {"falcon<4", "falcon-multipart==0.2.0"} | trigger_extras
@@ -21,7 +20,8 @@ gunicorn_extras = {
     "gunicorn<20.1; python_version < '3.6'",
     "gunicorn==20.1.*; python_version >= '3.6'",
 }
-uwsgi_extras = {"uwsgi==2.0.*"}
+uwsgi_max_extras = {"uwsgi==2.0.*"}
+uwsgi_min_extras = {"uwsgi==2.0.14"}
 pyramid_extras = {"pyramid<2", "waitress<2.1"} | trigger_extras
 
 wsgi_extras = trigger_extras
@@ -38,7 +38,7 @@ all_extras = (
     | wsgi_extras
     | dev_extras
     | bottle_extras
-    | uwsgi_extras
+    | uwsgi_max_extras
     | fastapi_extras
     | gunicorn_extras
 )
@@ -81,7 +81,8 @@ setup(
         "bottle": bottle_extras,
         "wsgi": wsgi_extras,
         "trigger": trigger_extras,
-        "uwsgi": uwsgi_extras,
+        "uwsgi-max": uwsgi_max_extras,
+        "uwsgi-min": uwsgi_min_extras,
         "gunicorn": gunicorn_extras,
     },
 )


### PR DESCRIPTION
- Adds `uwsgi-old` extra dependency option for uwsgi 2.0.14
- Removes `falcon` make target in favor of `falcon-gunicorn`. `make falcon` now produces a make error with a helpful message. I went back and forth on this, but since falcon doesn't have a dev server, it's required that users install a prod server explicitly. I wanted to avoid the case where a user tries `pip install .[falcon] && make falcon`, which would fail. This also makes falcon consistent with all other frameworks, which is useful for internal testing purposes