### PR TITLE
Add --master and --lazy-apps to uwsgi CLI options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 HOST ?= localhost
 PORT ?= 8000
-UWSGI_OPTIONS := --enable-threads --single-interpreter --http $(HOST):$(PORT)
+UWSGI_OPTIONS := --enable-threads --single-interpreter --master --lazy-apps --http $(HOST):$(PORT)
 GUNICORN_OPTIONS := --timeout=0 -b $(HOST):$(PORT)
 
 export VULNPY_REAL_SSRF_REQUESTS = true


### PR DESCRIPTION
After conducting some research it seems like these two CLI options are commonly used with uWSGI. If `--master` is used, we also require `--lazy-apps` for the contrast python agent to work correctly. This PR updates our default uWSGI flags to include both `--master` and `--lazy-apps`.