### PR TITLE
PYT-1648 Determine how to set forking / gUnicorn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 HOST ?= localhost
 PORT ?= 8000
 UWSGI_OPTIONS := --enable-threads --single-interpreter --master --lazy-apps --http $(HOST):$(PORT)
-GUNICORN_OPTIONS := --timeout=0 -b $(HOST):$(PORT)
+GUNICORN_OPTIONS := --timeout=0 --preload -b $(HOST):$(PORT)
 
 export VULNPY_REAL_SSRF_REQUESTS = true
 


### PR DESCRIPTION
After reading gunicorn’s docs and some examples from SOF. The best option related to forking is to use pre-fork mode (--preload). This mode initialise our code in a "master" process and then simply fork off worker processes to handle requests. 

Passing pipeline:
https://github.com/Contrast-Security-Inc/python-agent/actions/runs/1229423154