### PR TITLE
PYT-1728 add FastAPI routes that will be run in a threadpool

### DIFF
--- a/src/vulnpy/fastapi/vulnerable.py
+++ b/src/vulnpy/fastapi/vulnerable.py
@@ -45,6 +45,24 @@ def get_trigger_view(name, trigger):
         return HTMLResponse(template)
 
 
+def get_trigger_view_sync(name, trigger):
+    view_name = get_trigger_name(name, trigger) + "threadpool"
+
+    @router.get(path=view_name, name=view_name)
+    def _sync_view(user_input: str):
+        trigger_func = get_trigger(name, trigger)
+
+        if trigger_func:
+            trigger_func(user_input)
+
+        template = get_template("{}.html".format(name))
+
+        if name == "xss" and trigger == "raw":
+            template += "<p>XSS: " + user_input + "</p>"
+
+        return HTMLResponse(template)
+
+
 def generate_root_urls():
     for name in TRIGGER_MAP:
         gen_root_view(name)
@@ -54,6 +72,7 @@ def generate_trigger_urls():
     for name, triggers in TRIGGER_MAP.items():
         for trigger in triggers:
             get_trigger_view(name, trigger)
+            get_trigger_view_sync(name, trigger)
 
 
 generate_root_urls()


### PR DESCRIPTION
This PR adds routes that are defined without async. When this happens FastAPI runs them in an external thread pool. 