### PR TITLE
Pin fastapi back to 0.86 for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ django_extras = {"Django<4"} | trigger_extras
 falcon_extras = {"falcon<4", "falcon-multipart==0.2.0"} | trigger_extras
 flask_extras = {"Flask<3"} | trigger_extras
 fastapi_extras = {
-    "fastapi<1; python_version >= '3.6'",
+    "fastapi==0.68.*; python_version >= '3.6'",
     "uvicorn[standard]; python_version >= '3.6'",
     "python-multipart<1",
 } | trigger_extras


### PR DESCRIPTION
Pin FastAPI back to 0.68 until we resolve issues with 0.70