### PR TITLE
remove jinja2 from aiohttp

### DIFF
--- a/apps/aiohttp_app.py
+++ b/apps/aiohttp_app.py
@@ -1,6 +1,4 @@
 from aiohttp import web
-import aiohttp_jinja2
-import jinja2
 
 from vulnpy.aiohttp import vulnerable_routes
 
@@ -14,8 +12,6 @@ def index(request):
 
 def init_app(argv):
     app = web.Application()
-    aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader("src/vulnpy/templates/"))
-
     app.add_routes(routes)
     app.add_routes(vulnerable_routes)
 

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,7 @@ except IOError:
     README = ""
 
 trigger_extras = {"PyYAML<6", "lxml>=4.3.1", "mock==3.*"}
-aiohttp_extras = {
-    "aiohttp==3.7.*; python_version >= '3.7'",
-    "aiohttp-jinja2==1.5.*; python_version >= '3.7'",
-} | trigger_extras
+aiohttp_extras = {"aiohttp==3.7.*; python_version >= '3.7'"} | trigger_extras
 django_extras = {"Django<4"} | trigger_extras
 falcon_extras = {"falcon<4", "falcon-multipart==0.2.0"} | trigger_extras
 flask_extras = {"Flask<3"} | trigger_extras

--- a/src/vulnpy/aiohttp/vulnerable_routes.py
+++ b/src/vulnpy/aiohttp/vulnerable_routes.py
@@ -1,5 +1,4 @@
 from aiohttp import web
-import aiohttp_jinja2
 from vulnpy.common import get_template
 from vulnpy.trigger import TRIGGER_MAP, get_trigger
 
@@ -10,10 +9,8 @@ def _get_user_input(request):
 
 def gen_root_view(name):
     async def _root_view(request):
-        response = aiohttp_jinja2.render_template(
-            "{}.html".format(name), request, context={}
-        )
-        return response
+        template = get_template("{}.html".format(name))
+        return web.Response(text=template, content_type="text/html")
 
     return _root_view
 
@@ -26,15 +23,12 @@ def get_trigger_view(name, trigger):
         if trigger_func:
             trigger_func(user_input)
 
+        template = get_template("{}.html".format(name))
+
         if name == "xss" and trigger == "raw":
-            template = get_template("{}.html".format(name))
             template += "<p>XSS: " + user_input + "</p>"
-            response = web.Response(text=template)
-        else:
-            response = aiohttp_jinja2.render_template(
-                "{}.html".format(name), request, context={}
-            )
-        return response
+
+        return web.Response(text=template, content_type="text/html")
 
     return _view
 

--- a/tests/aiohttp/test_vulnerable_async.py
+++ b/tests/aiohttp/test_vulnerable_async.py
@@ -7,9 +7,6 @@ if sys.version_info < (3, 7):
 
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer, loop_context
-import aiohttp_jinja2
-import jinja2
-
 from vulnpy.aiohttp import vulnerable_routes  # noqa: E402
 
 from vulnpy.trigger import DATA  # noqa: E402
@@ -18,7 +15,6 @@ from tests import parametrize_root, parametrize_triggers  # noqa: E402
 
 def _create_example_app():
     app = web.Application()
-    aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader("src/vulnpy/templates/"))
     app.add_routes(vulnerable_routes)
     return app
 


### PR DESCRIPTION
I initially added aiohttp jinja2 support thinking I couldn't get template rendering to work, but Peter found the way! Just change the content type and voila!