### PR TITLE
vulnpy aio routes rename func

### DIFF
--- a/apps/aiohttp_app.py
+++ b/apps/aiohttp_app.py
@@ -1,5 +1,5 @@
 from aiohttp import web
-
+import os
 from vulnpy.aiohttp import vulnerable_routes
 
 routes = web.RouteTableDef()
@@ -11,7 +11,14 @@ def index(request):
 
 
 def init_app(argv):
-    app = web.Application()
+    middlewares = []
+
+    if os.environ.get("VULNPY_USE_CONTRAST"):
+        from contrast.aiohttp import ContrastMiddleware
+
+        middlewares = [ContrastMiddleware(app_name="vulnpy app")]
+
+    app = web.Application(middlewares=middlewares)
     app.add_routes(routes)
     app.add_routes(vulnerable_routes)
 

--- a/src/vulnpy/aiohttp/vulnerable_routes.py
+++ b/src/vulnpy/aiohttp/vulnerable_routes.py
@@ -48,6 +48,7 @@ def generate_root_urls():
     for name in TRIGGER_MAP:
         view_name = get_root_name(name)
         view_func = gen_root_view(name)
+        setattr(view_func, "__name__", view_name)
 
         root_urls.append(web.get(view_name, view_func))
         # aiohttp doesn't have automatic redirect if trailing slash is added
@@ -66,6 +67,7 @@ def generate_trigger_urls():
             view_name = get_trigger_name(name, trigger)
             view_func = get_trigger_view(name, trigger)
 
+            setattr(view_func, "__name__", view_name)
             trigger_urls.append(web.get(view_name, view_func))
 
     return trigger_urls


### PR DESCRIPTION
**For Contrast Python Developers Only**:

- [x] I've created a PR to update the vulnpy commit

- [ ] We do not want to update to this PR's top commit.


Add Contrast to aiohttp app. Because of our generic way of defining vulnpy routes, I had to set the function name for each route function so they don't all get named the same.

