### PR TITLE
up fastapi to support 0.75.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ django_extras = {"Django<5"} | trigger_extras
 falcon_extras = {"falcon<4", "falcon-multipart==0.2.0"} | trigger_extras
 flask_extras = {"Flask<3"} | trigger_extras
 fastapi_extras = {
-    "fastapi<=0.74",
+    "fastapi<0.76",
     "uvicorn[standard]",
     "python-multipart<1",
 } | trigger_extras


### PR DESCRIPTION
Using <0.76 because =< was not allowing for micro version install other than 0

**For Contrast Python Developers Only**:

- [ ] I've created a PR to update the vulnpy commit

- [ ] We do not want to update to this PR's top commit. Not yet, future PR, this won't break our pipeline



