### PR TITLE
Added support for fastapi 0.76

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ django_extras = {"Django<5"} | trigger_extras
 falcon_extras = {"falcon<4", "falcon-multipart==0.2.0"} | trigger_extras
 flask_extras = {"Flask<3"} | trigger_extras
 fastapi_extras = {
-    "fastapi<0.76",
+    "fastapi<0.77",
     "uvicorn[standard]",
     "python-multipart<1",
 } | trigger_extras


### PR DESCRIPTION
**For Contrast Python Developers Only**:

- [x] I've created a PR to update the vulnpy commit

- [ ] We do not want to update to this PR's top commit.



