### PR TITLE
PYT-2389 Add insecure Strict-Transport-Security header

### DIFF
--- a/src/vulnpy/wsgi/app.py
+++ b/src/vulnpy/wsgi/app.py
@@ -33,6 +33,7 @@ def vulnerable_app(environ, start_response):
     headers.append(("Cache-Control", "public"))
     # This makes the app vulnerable to X-XSS-Protection disabled
     headers.append(("X-XSS-Protection", "0"))
+    headers.append(("Strict-Transport-Security", "max-age=0"))
 
     start_response("200 OK", headers)
 


### PR DESCRIPTION
Makes vulnpy's WSGI app vulnerable to a bad HSTS response header.


**For Contrast Python Developers Only**:

- [x] I've created a PR to update the vulnpy commit

- [ ] We do not want to update to this PR's top commit.



