### PR TITLE
PYT-2593 enable django debug when standing up vulnpy live

### DIFF
--- a/apps/django_app.py
+++ b/apps/django_app.py
@@ -24,6 +24,8 @@ if not settings.configured:
             "ROOT_URLCONF": "django_app"
             if __name__ == "__main__"
             else "apps.django_app",
+            "SECRET_KEY": "test_key",  # pragma: allowlist secret
+            "DEBUG": True,
             "ALLOWED_HOSTS": ["localhost", "127.0.0.1", "[::1]"],
             "WSGI_APPLICATION": "django_app.vulnpy_app",
         }


### PR DESCRIPTION
**For Contrast Python Developers Only**:

- [x] I've created a PR to update the vulnpy commit

- [ ] We do not want to update to this PR's top commit.

Making this request `http://localhost:8000/vulnpy/deserialization/pickle-load/?user_input=testinput` will cause the django debug template to render


