### PR TITLE
Add jinja template xss to flask app

### DIFF
--- a/apps/flask_app.py
+++ b/apps/flask_app.py
@@ -1,11 +1,29 @@
 import os
+from pathlib import Path
 
-from flask import Flask, redirect
+from flask import Blueprint, Flask, redirect, request
+from jinja2 import Environment, FileSystemLoader
 
 from vulnpy.flask.blueprint import vulnerable_blueprint
 
+
+loader = FileSystemLoader(Path(__file__).parent / "templates" / "jinja")
+environment = Environment(loader=loader)
+
+template_blueprint = Blueprint("template-xss", __name__, url_prefix="/template-xss")
+
+
+@template_blueprint.get("/jinja")
+def jinja_xss():
+    template = environment.get_template("xss.html")
+    return template.render(
+        path="/template-xss/jinja", user_input=request.args.get("user_input", "")
+    )
+
+
 app = Flask(__name__)
 app.register_blueprint(vulnerable_blueprint)
+app.register_blueprint(template_blueprint)
 
 
 app.config["SESSION_COOKIE_SECURE"] = False

--- a/apps/templates/jinja/xss.html
+++ b/apps/templates/jinja/xss.html
@@ -1,0 +1,34 @@
+{% block content %}
+<h1>XSS</h1>
+<div class="column is-8">
+    <p>Any input entered will be displayed on this page</p>
+    <p>Example:
+        <xmp><img src="nonexistent-file.png" onerror=alert(document.cookie);></xmp>
+    </p>
+
+    <br>
+    <form action="{{ path }}" method="get">
+        <div class="field has-addons">
+            <div class="control">
+                <input class="input" type="text" name="user_input" placeholder="user_input">
+            </div>
+            <div class="control">
+                <button class="button is-info" action="submit">
+                    Submit
+                </button>
+            </div>
+        </div>
+    </form>
+
+    {% if error %}
+
+    Error: {{ error }}
+
+    {% endif %}
+
+    <div>
+        {{ user_input | safe }}
+    </div>
+
+</div>
+{% endblock %}


### PR DESCRIPTION
* Adds a route to the flask app that includes a reflected XSS vulnerability using `jinja` templates
* This does not include a change to vulnpy itself since it would be difficult to support across all frameworks

**For Contrast Python Developers Only**:

- [x] I've created a PR to update the vulnpy commit
- [ ] We do not want to update to this PR's top commit.



