### PR TITLE
fix Bottle app initialization

### DIFF
--- a/apps/bottle_app.py
+++ b/apps/bottle_app.py
@@ -4,7 +4,7 @@ from bottle import Bottle, run, redirect
 from vulnpy.bottle import add_vulnerable_routes
 
 
-app = Bottle(__name__)
+app = Bottle()
 add_vulnerable_routes(app)
 
 

--- a/tests/bottle/test_vulnerable.py
+++ b/tests/bottle/test_vulnerable.py
@@ -8,7 +8,7 @@ from webtest import TestApp
 
 @pytest.fixture(scope="module")
 def client():
-    app = Bottle(__name__)
+    app = Bottle()
     add_vulnerable_routes(app)
     return TestApp(app)
 


### PR DESCRIPTION
Bottle 0.13.0 requires Bottle instances to be initialized with keyword arguments only. Previously, we were using a positional argument. This usage was wrong (passing the __name__ string as a catchall boolean parameter), so it's removed.

**For Contrast Python Developers Only**:

- [x] I've created a PR to update the vulnpy commit

- [ ] We do not want to update to this PR's top commit.



