### PR TITLE
bump falcon requirement to <5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except IOError:
 trigger_extras = {"PyYAML<7", "lxml>=4.3.1", "mock==3.*"}
 aiohttp_extras = {"aiohttp<4"} | trigger_extras
 django_extras = {"Django<6"} | trigger_extras
-falcon_extras = {"falcon<4", "falcon-multipart==0.2.0"} | trigger_extras
+falcon_extras = {"falcon<5", "falcon-multipart==0.2.0"} | trigger_extras
 flask_extras = {"Flask<4"} | trigger_extras
 fastapi_extras = {
     "fastapi<1",

--- a/src/vulnpy/falcon/vulnerable.py
+++ b/src/vulnpy/falcon/vulnerable.py
@@ -114,7 +114,7 @@ def _set_response(resp, path):
     """
     Set the response body and Content-Type
     """
-    resp.body = get_template(path)
+    resp.text = get_template(path)
     resp.content_type = "text/html"
 
 
@@ -122,5 +122,5 @@ def _set_xss_response(resp, path, user_input):
     template = get_template(path)
     template += "<p>XSS: " + user_input + "</p>"
 
-    resp.body = template
+    resp.text = template
     resp.content_type = "text/html"

--- a/tests/falcon/test_vulnerable.py
+++ b/tests/falcon/test_vulnerable.py
@@ -13,7 +13,7 @@ from tests import parametrize_root, parametrize_triggers
 
 @pytest.fixture(scope="module")
 def client():
-    app = falcon.API()
+    app = falcon.App()
     vulnpy.falcon.add_vulnerable_routes(app)
     return testing.TestClient(app)
 

--- a/tests/falcon/test_vulnerable_asgi.py
+++ b/tests/falcon/test_vulnerable_asgi.py
@@ -12,7 +12,7 @@ from tests import parametrize_root, parametrize_triggers
 
 
 @pytest.fixture(scope="module")
-def client():
+async def client():
     app = falcon.asgi.App()
     vulnpy.falcon.add_vulnerable_asgi_routes(app)
     return testing.TestClient(app)


### PR DESCRIPTION
falcon<4 doesn't support Python 3.13. Bump the requirement to allow the latest Python version.

**For Contrast Python Developers Only**:

- [x] I've created a PR to update the vulnpy commit

- [ ] We do not want to update to this PR's top commit.



